### PR TITLE
Feature/db update

### DIFF
--- a/Project/.gitignore
+++ b/Project/.gitignore
@@ -74,3 +74,4 @@ dotnet-install.sh
 
 # Test results and coverage reports (generated — regenerate locally)
 TelecomSupportSystem/TestResults/
+coverage/

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
@@ -126,8 +126,22 @@ if (app.Environment.IsDevelopment())
     using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-    // DODANO: Kreira bazu i tabele ako ne postoje
-    db.Database.EnsureCreated();
+    var retries = 10;
+    var delay = TimeSpan.FromSeconds(3);
+    while (retries > 0)
+    {
+        try
+        {
+            db.Database.Migrate();
+            break;
+        }
+        catch
+        {
+            retries--;
+            if (retries == 0) throw;
+            Thread.Sleep(delay);
+        }
+    }
 
     // add users if not existant
     if (!db.Users.Any())

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
@@ -141,7 +141,7 @@ if (app.Environment.IsDevelopment())
                 Username = "admin",
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword("Admin123!"),
                 Phone = "",
-                Address = "",
+                Location = "",
                 Role = Role.ADMINISTRATOR,
                 AccountStatus = AccountStatus.ACTIVE
             },
@@ -153,7 +153,7 @@ if (app.Environment.IsDevelopment())
                 Username = "agent",
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"),
                 Phone = "",
-                Address = "",
+                Location = "",
                 Role = Role.AGENT,
                 AccountStatus = AccountStatus.ACTIVE
             },
@@ -165,7 +165,7 @@ if (app.Environment.IsDevelopment())
                 Username = "client",
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword("Client123!"),
                 Phone = "",
-                Address = "",
+                Location = "Sarajevo",
                 Role = Role.CLIENT,
                 AccountStatus = AccountStatus.ACTIVE
             },
@@ -177,7 +177,7 @@ if (app.Environment.IsDevelopment())
                 Username = "Joohnyy",
                 PasswordHash = BCrypt.Net.BCrypt.HashPassword("Johny123!"),
                 Phone = "",
-                Address = "",
+                Location = "Mostar",
                 Role = Role.CLIENT,
                 AccountStatus = AccountStatus.ACTIVE
             }
@@ -198,6 +198,67 @@ if (app.Environment.IsDevelopment())
             new Ticket { Title = "Tehnička podrška za ruter", Description = "Trebam pomoć sa konfiguracijom rutera.", CreatedDate = DateTime.UtcNow.AddDays(-6), Status = TicketStatus.CLOSED, ClosedDate = DateTime.UtcNow.AddDays(-3), Priority = Priority.LOW, ProblemCategory = ProblemCategory.TECHNICAL_SUPPORT, CreatorId = clientId },
             new Ticket { Title = "TV aplikacija ne radi", Description = "Ne mogu pristupiti TV aplikaciji.", CreatedDate = DateTime.UtcNow.AddDays(-8), Status = TicketStatus.OPEN, Priority = Priority.MEDIUM, ProblemCategory = ProblemCategory.TV, CreatorId = clientId },
             new Ticket { Title = "Prekid usluge bez obavijesti", Description = "Usluga je prekinuta bez ikakve najave.", CreatedDate = DateTime.UtcNow.AddDays(-9), Status = TicketStatus.CLOSED, ClosedDate = DateTime.UtcNow.AddDays(-5), Priority = Priority.HIGH, ProblemCategory = ProblemCategory.TECHNICAL_SUPPORT, CreatorId = clientId }
+        );
+        db.SaveChanges();
+    }
+
+    if (!db.Teams.Any())
+    {
+        db.Teams.AddRange(
+            new Team { TeamName = "Internet Tim", Description = "Agenti specijalizovani za probleme s internetom.", TeamType = TeamType.AGENTS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = ProblemCategory.INTERNET },
+            new Team { TeamName = "TV Tim", Description = "Agenti specijalizovani za TV probleme.", TeamType = TeamType.AGENTS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = ProblemCategory.TV },
+            new Team { TeamName = "Mobilni Tim", Description = "Agenti specijalizovani za mobilnu mrežu.", TeamType = TeamType.AGENTS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = ProblemCategory.MOBILE_NETWORK },
+            new Team { TeamName = "Naplata Tim", Description = "Agenti specijalizovani za račune i naplatu.", TeamType = TeamType.AGENTS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = ProblemCategory.BILLING },
+            new Team { TeamName = "Tehnička Podrška Tim", Description = "Agenti specijalizovani za tehničku podršku.", TeamType = TeamType.AGENTS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = ProblemCategory.TECHNICAL_SUPPORT },
+            new Team { TeamName = "Tehničari Tim", Description = "Terenski tehničari.", TeamType = TeamType.TECHNICIANS, TeamStatus = TeamStatus.ACTIVE, SpecializedCategory = null }
+        );
+        db.SaveChanges();
+    }
+
+    if (!db.Users.Any(u => u.Role == Role.AGENT && u.TeamId != null))
+    {
+        var internetTeamId = db.Teams.First(t => t.SpecializedCategory == ProblemCategory.INTERNET).TeamId;
+        var tvTeamId = db.Teams.First(t => t.SpecializedCategory == ProblemCategory.TV).TeamId;
+        var mobileTeamId = db.Teams.First(t => t.SpecializedCategory == ProblemCategory.MOBILE_NETWORK).TeamId;
+        var billingTeamId = db.Teams.First(t => t.SpecializedCategory == ProblemCategory.BILLING).TeamId;
+        var techSupportTeamId = db.Teams.First(t => t.SpecializedCategory == ProblemCategory.TECHNICAL_SUPPORT).TeamId;
+
+        db.Users.AddRange(
+            // Internet Tim
+            new User { FirstName = "Amina", LastName = "Hodžić", Email = "amina.hodzic@telecom.ba", Username = "amina.hodzic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = internetTeamId },
+            new User { FirstName = "Emir", LastName = "Kovač", Email = "emir.kovac@telecom.ba", Username = "emir.kovac", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = internetTeamId },
+            new User { FirstName = "Lejla", LastName = "Softić", Email = "lejla.softic@telecom.ba", Username = "lejla.softic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = internetTeamId },
+            // TV Tim
+            new User { FirstName = "Dino", LastName = "Muratović", Email = "dino.muratovic@telecom.ba", Username = "dino.muratovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = tvTeamId },
+            new User { FirstName = "Sara", LastName = "Begić", Email = "sara.begic@telecom.ba", Username = "sara.begic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = tvTeamId },
+            new User { FirstName = "Haris", LastName = "Čolić", Email = "haris.colic@telecom.ba", Username = "haris.colic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Sarajevo", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = tvTeamId },
+            // Mobilni Tim
+            new User { FirstName = "Maja", LastName = "Halilović", Email = "maja.halilovic@telecom.ba", Username = "maja.halilovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Mostar", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = mobileTeamId },
+            new User { FirstName = "Tarik", LastName = "Džanić", Email = "tarik.dzanic@telecom.ba", Username = "tarik.dzanic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Mostar", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = mobileTeamId },
+            new User { FirstName = "Nela", LastName = "Selimović", Email = "nela.selimovic@telecom.ba", Username = "nela.selimovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Mostar", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = mobileTeamId },
+            // Naplata Tim
+            new User { FirstName = "Kenan", LastName = "Imamović", Email = "kenan.imamovic@telecom.ba", Username = "kenan.imamovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Banja Luka", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = billingTeamId },
+            new User { FirstName = "Alma", LastName = "Karić", Email = "alma.karic@telecom.ba", Username = "alma.karic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Banja Luka", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = billingTeamId },
+            new User { FirstName = "Nermin", LastName = "Zukić", Email = "nermin.zukic@telecom.ba", Username = "nermin.zukic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Banja Luka", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = billingTeamId },
+            // Tehnička Podrška Tim
+            new User { FirstName = "Irma", LastName = "Spahić", Email = "irma.spahic@telecom.ba", Username = "irma.spahic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Tuzla", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techSupportTeamId },
+            new User { FirstName = "Adnan", LastName = "Mešić", Email = "adnan.mesic@telecom.ba", Username = "adnan.mesic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Tuzla", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techSupportTeamId },
+            new User { FirstName = "Belma", LastName = "Fočo", Email = "belma.foco@telecom.ba", Username = "belma.foco", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Agent123!"), Phone = "", Location = "Tuzla", Role = Role.AGENT, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techSupportTeamId }
+        );
+        db.SaveChanges();
+    }
+
+    if (!db.Users.Any(u => u.Role == Role.TECHNICIAN))
+    {
+        var techTeamId = db.Teams.First(t => t.TeamType == TeamType.TECHNICIANS).TeamId;
+
+        db.Users.AddRange(
+            new User { FirstName = "Mirza", LastName = "Omerović", Email = "mirza.omerovic@telecom.ba", Username = "mirza.omerovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Sarajevo", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId },
+            new User { FirstName = "Damir", LastName = "Čaušević", Email = "damir.causevic@telecom.ba", Username = "damir.causevic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Sarajevo", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId },
+            new User { FirstName = "Vedran", LastName = "Bajrić", Email = "vedran.bajric@telecom.ba", Username = "vedran.bajric", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Mostar", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId },
+            new User { FirstName = "Jasmina", LastName = "Hadžić", Email = "jasmina.hadzic@telecom.ba", Username = "jasmina.hadzic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Mostar", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId },
+            new User { FirstName = "Sanel", LastName = "Petrović", Email = "sanel.petrovic@telecom.ba", Username = "sanel.petrovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Banja Luka", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId },
+            new User { FirstName = "Azra", LastName = "Numanović", Email = "azra.numanovic@telecom.ba", Username = "azra.numanovic", PasswordHash = BCrypt.Net.BCrypt.HashPassword("Tech123!"), Phone = "", Location = "Tuzla", Role = Role.TECHNICIAN, AccountStatus = AccountStatus.ACTIVE, AvailabilityStatus = AvailabilityStatus.AVAILABLE, TeamId = techTeamId }
         );
         db.SaveChanges();
     }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/AppDbContext.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/AppDbContext.cs
@@ -39,7 +39,7 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.Username).IsRequired().HasMaxLength(100);
             entity.Property(e => e.PasswordHash).IsRequired();
             entity.Property(e => e.Phone).HasMaxLength(20);
-            entity.Property(e => e.Address).HasMaxLength(500);
+            entity.Property(e => e.Location).HasMaxLength(500);
 
             entity.HasIndex(e => e.Email).IsUnique();
             entity.HasIndex(e => e.Username).IsUnique();
@@ -150,6 +150,7 @@ public class ApplicationDbContext : DbContext
 
             entity.Property(e => e.PackageName).IsRequired().HasMaxLength(100);
             entity.Property(e => e.PackageDescription).HasMaxLength(500);
+            entity.Property(e => e.MonthlyPrice).HasPrecision(18, 2);
 
             entity.HasIndex(e => e.UserId);
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Enums/AssignmentType.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Enums/AssignmentType.cs
@@ -7,6 +7,8 @@ namespace TelecomSupportSystem.DAL.Entities.Enums
     public enum AssignmentType
     {
         AUTOMATIC = 1,
-        MANUAL = 2
+        MANUAL = 2,
+        FORWARDED_TO_AGENT = 3,
+        FORWARDED_TO_TECHNICIAN = 4
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Team.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Team.cs
@@ -12,6 +12,7 @@ namespace TelecomSupportSystem.DAL.Entities
         public string Description { get; set; } = string.Empty;
         public TeamType TeamType { get; set; }
         public TeamStatus TeamStatus { get; set; }
+        public ProblemCategory? SpecializedCategory { get; set; }
 
         public ICollection<User> Members { get; set; } = new List<User>();
         public ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/User.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/User.cs
@@ -13,7 +13,7 @@ namespace TelecomSupportSystem.DAL.Entities
         public string LastName { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
         public string Phone { get; set; } = string.Empty;
-        public string Address { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;
         public string PasswordHash { get; set; } = string.Empty;
         public AccountStatus AccountStatus { get; set; }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095506_Sprint7_DbRefactor.Designer.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095506_Sprint7_DbRefactor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelecomSupportSystem.DAL;
 
@@ -11,9 +12,11 @@ using TelecomSupportSystem.DAL;
 namespace TelecomSupportSystem.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509095506_Sprint7_DbRefactor")]
+    partial class Sprint7_DbRefactor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -66,7 +69,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AuditLogs", (string)null);
+                    b.ToTable("AuditLogs");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Comment", b =>
@@ -101,7 +104,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("TicketId");
 
-                    b.ToTable("Comments", (string)null);
+                    b.ToTable("Comments");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Faq", b =>
@@ -141,7 +144,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("SortOrder");
 
-                    b.ToTable("Faqs", (string)null);
+                    b.ToTable("Faqs");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Notification", b =>
@@ -181,7 +184,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("Notifications", (string)null);
+                    b.ToTable("Notifications");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.PackageFeature", b =>
@@ -219,7 +222,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("PackageId");
 
-                    b.ToTable("PackageFeatures", (string)null);
+                    b.ToTable("PackageFeatures");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Rating", b =>
@@ -253,7 +256,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("Ratings", (string)null);
+                    b.ToTable("Ratings");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.RefreshToken", b =>
@@ -288,7 +291,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("RefreshTokens", (string)null);
+                    b.ToTable("RefreshTokens");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Report", b =>
@@ -322,7 +325,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("ReportType");
 
-                    b.ToTable("Reports", (string)null);
+                    b.ToTable("Reports");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.SubscriptionPackage", b =>
@@ -334,7 +337,6 @@ namespace TelecomSupportSystem.DAL.Migrations
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("PackageId"));
 
                     b.Property<decimal>("MonthlyPrice")
-                        .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("PackageDescription")
@@ -360,7 +362,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("SubscriptionPackages", (string)null);
+                    b.ToTable("SubscriptionPackages");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Team", b =>
@@ -392,7 +394,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasKey("TeamId");
 
-                    b.ToTable("Teams", (string)null);
+                    b.ToTable("Teams");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Ticket", b =>
@@ -445,7 +447,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("TeamId");
 
-                    b.ToTable("Tickets", (string)null);
+                    b.ToTable("Tickets");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.TicketUser", b =>
@@ -484,7 +486,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("TicketUser", (string)null);
+                    b.ToTable("TicketUser");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.User", b =>
@@ -551,7 +553,7 @@ namespace TelecomSupportSystem.DAL.Migrations
                     b.HasIndex("Username")
                         .IsUnique();
 
-                    b.ToTable("Users", (string)null);
+                    b.ToTable("Users");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Comment", b =>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095506_Sprint7_DbRefactor.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095506_Sprint7_DbRefactor.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelecomSupportSystem.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class Sprint7_DbRefactor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Address",
+                table: "Users",
+                newName: "Location");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SpecializedCategory",
+                table: "Teams",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SpecializedCategory",
+                table: "Teams");
+
+            migrationBuilder.RenameColumn(
+                name: "Location",
+                table: "Users",
+                newName: "Address");
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095647_Fix_MonthlyPricePrecision.Designer.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095647_Fix_MonthlyPricePrecision.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelecomSupportSystem.DAL;
 
@@ -11,9 +12,11 @@ using TelecomSupportSystem.DAL;
 namespace TelecomSupportSystem.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509095647_Fix_MonthlyPricePrecision")]
+    partial class Fix_MonthlyPricePrecision
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -66,7 +69,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AuditLogs", (string)null);
+                    b.ToTable("AuditLogs");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Comment", b =>
@@ -101,7 +104,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("TicketId");
 
-                    b.ToTable("Comments", (string)null);
+                    b.ToTable("Comments");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Faq", b =>
@@ -141,7 +144,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("SortOrder");
 
-                    b.ToTable("Faqs", (string)null);
+                    b.ToTable("Faqs");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Notification", b =>
@@ -181,7 +184,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("Notifications", (string)null);
+                    b.ToTable("Notifications");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.PackageFeature", b =>
@@ -219,7 +222,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("PackageId");
 
-                    b.ToTable("PackageFeatures", (string)null);
+                    b.ToTable("PackageFeatures");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Rating", b =>
@@ -253,7 +256,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("Ratings", (string)null);
+                    b.ToTable("Ratings");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.RefreshToken", b =>
@@ -288,7 +291,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("RefreshTokens", (string)null);
+                    b.ToTable("RefreshTokens");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Report", b =>
@@ -322,7 +325,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("ReportType");
 
-                    b.ToTable("Reports", (string)null);
+                    b.ToTable("Reports");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.SubscriptionPackage", b =>
@@ -360,7 +363,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("SubscriptionPackages", (string)null);
+                    b.ToTable("SubscriptionPackages");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Team", b =>
@@ -392,7 +395,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasKey("TeamId");
 
-                    b.ToTable("Teams", (string)null);
+                    b.ToTable("Teams");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Ticket", b =>
@@ -445,7 +448,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("TeamId");
 
-                    b.ToTable("Tickets", (string)null);
+                    b.ToTable("Tickets");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.TicketUser", b =>
@@ -484,7 +487,7 @@ namespace TelecomSupportSystem.DAL.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("TicketUser", (string)null);
+                    b.ToTable("TicketUser");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.User", b =>
@@ -551,7 +554,7 @@ namespace TelecomSupportSystem.DAL.Migrations
                     b.HasIndex("Username")
                         .IsUnique();
 
-                    b.ToTable("Users", (string)null);
+                    b.ToTable("Users");
                 });
 
             modelBuilder.Entity("TelecomSupportSystem.DAL.Entities.Comment", b =>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095647_Fix_MonthlyPricePrecision.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260509095647_Fix_MonthlyPricePrecision.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelecomSupportSystem.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class Fix_MonthlyPricePrecision : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
## Šta je urađeno
Pripremljena baza podataka za implementaciju automatske dodjele tiketa i prosljeđivanja tiketa.

### Promjene na modelu:

- Users.Address preimenovano u Users.Location (koristi se za geo-matching tehničara)
- Teams.SpecializedCategory (nullable) dodana — logička veza između tima i kategorije problema
- AssignmentType enum proširen sa FORWARDED_TO_AGENT i FORWARDED_TO_TECHNICIAN

### Seed podaci:

- 5 agent timova, svaki specijalizovan za jednu kategoriju (INTERNET, TV, MOBILE_NETWORK, BILLING, TECHNICAL_SUPPORT)
- 15 agenata (3 po timu) sa AvailabilityStatus i TeamId
- 6 tehničara sa Location (Sarajevo, Mostar, Banja Luka, Tuzla) za geo-matching

### Infrastruktura:

- EnsureCreated() zamijenjeno sa Migrate() — migracije se primjenjuju automatski na postojeću bazu bez gubitka podataka
- Dodana retry logika pri startu (10 pokušaja, 3s pauza) za slučaj da SQL Server još nije spreman

Ako imaš staru bazu — Migrate() automatski primijeni promjene, nema potrebe za dropom!!!