### PR TITLE
Feature/pb 42

### DIFF
--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/NotificationController.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/NotificationController.cs
@@ -1,6 +1,70 @@
-﻿namespace TelecomSupportSystem.API.Controllers
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+
+namespace TelecomSupportSystem.API.Controllers
 {
-    public class NotificationController
+    [ApiController]
+    [Route("api/notifications")]
+    [Authorize]
+    public class NotificationController : ControllerBase
     {
+        private readonly INotificationService _notificationService;
+
+        public NotificationController(INotificationService notificationService)
+        {
+            _notificationService = notificationService;
+        }
+
+        // GET /api/notifications
+        [HttpGet]
+        public async Task<IActionResult> GetMyNotifications()
+        {
+            var userId = GetUserId();
+            if (userId is null) return Unauthorized();
+
+            var notifications = await _notificationService.GetNotificationsAsync(userId.Value);
+            return Ok(notifications);
+        }
+
+        // POST /api/notifications/{id}/read
+        [HttpPost("{id}/read")]
+        public async Task<IActionResult> MarkAsRead(int id)
+        {
+            var userId = GetUserId();
+            if (userId is null) return Unauthorized();
+
+            try
+            {
+                await _notificationService.MarkAsReadAsync(id, userId.Value);
+                return NoContent();
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Forbid(ex.Message);
+            }
+        }
+
+        // POST /api/notifications/read-all
+        [HttpPost("read-all")]
+        public async Task<IActionResult> MarkAllAsRead()
+        {
+            var userId = GetUserId();
+            if (userId is null) return Unauthorized();
+
+            await _notificationService.MarkAllAsReadAsync(userId.Value);
+            return NoContent();
+        }
+
+        private int? GetUserId()
+        {
+            var claim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return int.TryParse(claim, out int id) ? id : null;
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/UserController.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/UserController.cs
@@ -1,6 +1,54 @@
-﻿namespace TelecomSupportSystem.API.Controllers
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+
+namespace TelecomSupportSystem.API.Controllers
 {
-    public class UserController
+    [ApiController]
+    [Route("api/users")]
+    [Authorize]
+    public class UserController : ControllerBase
     {
+        private readonly IUserService _userService;
+
+        public UserController(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        // PB-42: GET /api/users/me/statistics — statistika rada za agenta ili tehničara
+        [HttpGet("me/statistics")]
+        public async Task<IActionResult> GetMyStatistics()
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (userIdClaim is null || !int.TryParse(userIdClaim, out int userId) || role is null)
+                return Unauthorized();
+
+            if (role != "AGENT" && role != "TECHNICIAN")
+                return Forbid();
+
+            var stats = await _userService.GetMyStatisticsAsync(userId, role);
+            return Ok(stats);
+        }
+
+        // Dashboard: GET /api/users/me/recent-tickets — 5 najrecentnijih tiketa
+        [HttpGet("me/recent-tickets")]
+        public async Task<IActionResult> GetRecentTickets()
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (userIdClaim is null || !int.TryParse(userIdClaim, out int userId) || role is null)
+                return Unauthorized();
+
+            if (role != "AGENT" && role != "TECHNICIAN")
+                return Forbid();
+
+            var tickets = await _userService.GetRecentAssignedTicketsAsync(userId);
+            return Ok(tickets);
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Hubs/NotificationHub.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Hubs/NotificationHub.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace TelecomSupportSystem.API.Hubs
+{
+    [Authorize]
+    public class NotificationHub : Hub
+    {
+        public async Task JoinUserGroup(string userId)
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"user_{userId}");
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
@@ -11,6 +11,8 @@ using TelecomSupportSystem.DAL.Repositories;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
 using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.API.Hubs;
+using TelecomSupportSystem.API.Workers;
 
 DotNetEnv.Env.Load(".env", new DotNetEnv.LoadOptions(clobberExistingVars: false));
 DotNetEnv.Env.Load("../../.env", new DotNetEnv.LoadOptions(clobberExistingVars: false));
@@ -61,6 +63,18 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
         };
+        // SignalR sends JWT via query string
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                var accessToken = context.Request.Query["access_token"];
+                var path = context.HttpContext.Request.Path;
+                if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/notificationhub"))
+                    context.Token = accessToken;
+                return Task.CompletedTask;
+            }
+        };
     });
 
 //for REACT frontent port: 5173
@@ -110,6 +124,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ITicketService, TicketService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<INotificationPusher, NotificationPusher>();
 builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddScoped<IFaqService, FaqService>();
 
@@ -440,6 +455,7 @@ app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-app.MapHub<TelecomSupportSystem.API.Hubs.ChatHub>("/chathub");
+app.MapHub<ChatHub>("/chathub");
+app.MapHub<NotificationHub>("/notificationhub");
 
 app.Run();

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Program.cs
@@ -125,6 +125,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ITicketService, TicketService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<INotificationPusher, NotificationPusher>();
+builder.Services.AddScoped<IChatPusher, ChatPusher>();
 builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddScoped<IFaqService, FaqService>();
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Workers/ChatPusher.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Workers/ChatPusher.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.SignalR;
+using TelecomSupportSystem.API.Hubs;
+using TelecomSupportSystem.BLL.DTOs.Comments;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+
+namespace TelecomSupportSystem.API.Workers
+{
+    public class ChatPusher : IChatPusher
+    {
+        private readonly IHubContext<ChatHub> _hubContext;
+
+        public ChatPusher(IHubContext<ChatHub> hubContext)
+        {
+            _hubContext = hubContext;
+        }
+
+        public async Task PushCommentAsync(int ticketId, CommentDto dto)
+        {
+            await _hubContext.Clients.Group($"ticket_{ticketId}").SendAsync("ReceiveComment", dto);
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Workers/NotificationPusher.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Workers/NotificationPusher.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.SignalR;
+using TelecomSupportSystem.API.Hubs;
+using TelecomSupportSystem.BLL.DTOs.Notification;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+
+namespace TelecomSupportSystem.API.Workers
+{
+    public class NotificationPusher : INotificationPusher
+    {
+        private readonly IHubContext<NotificationHub> _hubContext;
+
+        public NotificationPusher(IHubContext<NotificationHub> hubContext)
+        {
+            _hubContext = hubContext;
+        }
+
+        public async Task PushAsync(int userId, GetNotifcationDto dto)
+        {
+            await _hubContext.Clients.Group($"user_{userId}").SendAsync("ReceiveNotification", dto);
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Comments/CommentDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Comments/CommentDto.cs
@@ -5,8 +5,9 @@ namespace TelecomSupportSystem.BLL.DTOs.Comments
         public int CommentId { get; set; }
         public string Content { get; set; } = string.Empty;
         public DateTime DateTime { get; set; }
-        public int AuthorId { get; set; }
+        public int? AuthorId { get; set; }
         public string AuthorName { get; set; } = string.Empty;
         public string AuthorRole { get; set; } = string.Empty;
+        public bool IsSystemMessage { get; set; }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Notification/GetNotifcationDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Notification/GetNotifcationDto.cs
@@ -8,5 +8,6 @@ namespace TelecomSupportSystem.BLL.DTOs.Notification
         public string NotificationType { get; set; } = string.Empty;
         public DateTime SentDate { get; set; }
         public bool IsRead { get; set; }
+        public int? TicketId { get; set; }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Notification/GetNotifcationDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Notification/GetNotifcationDto.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace TelecomSupportSystem.BLL.DTOs.Notification
 {
-    internal class GetNotifcationDto
+    public class GetNotifcationDto
     {
+        public int NotificationId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public string NotificationType { get; set; } = string.Empty;
+        public DateTime SentDate { get; set; }
+        public bool IsRead { get; set; }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Users/AgentStatisticsDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Users/AgentStatisticsDto.cs
@@ -1,0 +1,12 @@
+namespace TelecomSupportSystem.BLL.DTOs.Users
+{
+    public class AgentStatisticsDto
+    {
+        public int OpenTicketsCount { get; set; }
+        public int ClosedTicketsCount { get; set; }
+        public int PendingClosureCount { get; set; }
+        public double? AvgFirstResponseMinutes { get; set; }
+        public double? AvgResolutionHours { get; set; }
+        public double? AvgRating { get; set; }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Users/RecentTicketDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Users/RecentTicketDto.cs
@@ -1,0 +1,11 @@
+namespace TelecomSupportSystem.BLL.DTOs.Users
+{
+    public class RecentTicketDto
+    {
+        public int TicketId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Priority { get; set; } = string.Empty;
+        public DateTime LastActivityDate { get; set; }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
@@ -1,5 +1,6 @@
 using TelecomSupportSystem.BLL.DTOs.Comments;
 using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
 
 namespace TelecomSupportSystem.BLL.Services
@@ -8,11 +9,16 @@ namespace TelecomSupportSystem.BLL.Services
     {
         private readonly ICommentRepository _commentRepository;
         private readonly ITicketRepository _ticketRepository;
+        private readonly INotificationService _notificationService;
 
-        public CommentService(ICommentRepository commentRepository, ITicketRepository ticketRepository)
+        public CommentService(
+            ICommentRepository commentRepository,
+            ITicketRepository ticketRepository,
+            INotificationService notificationService)
         {
             _commentRepository = commentRepository;
             _ticketRepository = ticketRepository;
+            _notificationService = notificationService;
         }
 
         // US-15: Ista logika pristupa kao i za tiket (CLIENT → vlastiti, AGENT/TECHNICIAN → dodijeljeni, ADMIN → svi)
@@ -129,6 +135,29 @@ namespace TelecomSupportSystem.BLL.Services
 
             // Fetch the created comment to get author details
             var createdComment = (await _commentRepository.GetByTicketIdAsync(ticketId)).Last();
+
+            // TICKET_RESPONSE: klijent odgovori → notifikacija agentu/tehničaru; agent/tech odgovori → notifikacija klijentu
+            if (role == "CLIENT")
+            {
+                var currentAssignee = ticket.Assignments
+                    .OrderByDescending(a => a.AssignmentDate)
+                    .FirstOrDefault();
+
+                if (currentAssignee is not null)
+                    await _notificationService.SendNotificationAsync(
+                        currentAssignee.UserId,
+                        "Novi odgovor klijenta",
+                        $"Klijent je odgovorio na tiket \"{ticket.Title}\".",
+                        NotificationType.TICKET_RESPONSE);
+            }
+            else if (role is "AGENT" or "TECHNICIAN")
+            {
+                await _notificationService.SendNotificationAsync(
+                    ticket.CreatorId,
+                    "Odgovor na vaš tiket",
+                    $"Dobili ste odgovor na tiket \"{ticket.Title}\".",
+                    NotificationType.TICKET_RESPONSE);
+            }
 
             return new CommentDto
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
@@ -148,7 +148,8 @@ namespace TelecomSupportSystem.BLL.Services
                         currentAssignee.UserId,
                         "Novi odgovor klijenta",
                         $"Klijent je odgovorio na tiket \"{ticket.Title}\".",
-                        NotificationType.TICKET_RESPONSE);
+                        NotificationType.TICKET_RESPONSE,
+                        ticketId);
             }
             else if (role is "AGENT" or "TECHNICIAN")
             {
@@ -156,7 +157,8 @@ namespace TelecomSupportSystem.BLL.Services
                     ticket.CreatorId,
                     "Odgovor na vaš tiket",
                     $"Dobili ste odgovor na tiket \"{ticket.Title}\".",
-                    NotificationType.TICKET_RESPONSE);
+                    NotificationType.TICKET_RESPONSE,
+                    ticketId);
             }
 
             return new CommentDto

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/CommentService.cs
@@ -10,15 +10,18 @@ namespace TelecomSupportSystem.BLL.Services
         private readonly ICommentRepository _commentRepository;
         private readonly ITicketRepository _ticketRepository;
         private readonly INotificationService _notificationService;
+        private readonly IChatPusher _chatPusher;
 
         public CommentService(
             ICommentRepository commentRepository,
             ITicketRepository ticketRepository,
-            INotificationService notificationService)
+            INotificationService notificationService,
+            IChatPusher chatPusher)
         {
             _commentRepository = commentRepository;
             _ticketRepository = ticketRepository;
             _notificationService = notificationService;
+            _chatPusher = chatPusher;
         }
 
         // US-15: Ista logika pristupa kao i za tiket (CLIENT → vlastiti, AGENT/TECHNICIAN → dodijeljeni, ADMIN → svi)
@@ -44,12 +47,13 @@ namespace TelecomSupportSystem.BLL.Services
 
             return comments.Select(c => new CommentDto
             {
-                CommentId  = c.CommentId,
-                Content    = c.Content,
-                DateTime   = c.DateTime,
-                AuthorId   = c.AuthorId,
-                AuthorName = $"{c.Author.FirstName} {c.Author.LastName}",
-                AuthorRole = c.Author.Role.ToString(),
+                CommentId       = c.CommentId,
+                Content         = c.Content,
+                DateTime        = c.DateTime,
+                AuthorId        = c.AuthorId,
+                AuthorName      = c.IsSystemMessage ? string.Empty : $"{c.Author!.FirstName} {c.Author.LastName}",
+                AuthorRole      = c.IsSystemMessage ? string.Empty : c.Author!.Role.ToString(),
+                IsSystemMessage = c.IsSystemMessage,
             });
         }
 
@@ -163,13 +167,37 @@ namespace TelecomSupportSystem.BLL.Services
 
             return new CommentDto
             {
-                CommentId = createdComment.CommentId,
-                Content = createdComment.Content,
-                DateTime = createdComment.DateTime,
-                AuthorId = createdComment.AuthorId,
-                AuthorName = $"{createdComment.Author.FirstName} {createdComment.Author.LastName}",
-                AuthorRole = createdComment.Author.Role.ToString()
+                CommentId  = createdComment.CommentId,
+                Content    = createdComment.Content,
+                DateTime   = createdComment.DateTime,
+                AuthorId   = createdComment.AuthorId,
+                AuthorName = $"{createdComment.Author!.FirstName} {createdComment.Author.LastName}",
+                AuthorRole = createdComment.Author.Role.ToString(),
             };
+        }
+
+        public async Task AddSystemCommentAsync(int ticketId, string content)
+        {
+            var comment = new TelecomSupportSystem.DAL.Entities.Comment
+            {
+                TicketId        = ticketId,
+                Content         = content,
+                DateTime        = DateTime.UtcNow,
+                IsSystemMessage = true,
+                IsInternal      = false,
+            };
+
+            await _commentRepository.CreateAsync(comment);
+
+            var dto = new CommentDto
+            {
+                CommentId       = comment.CommentId,
+                Content         = comment.Content,
+                DateTime        = comment.DateTime,
+                IsSystemMessage = true,
+            };
+
+            await _chatPusher.PushCommentAsync(ticketId, dto);
         }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IChatPusher.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IChatPusher.cs
@@ -1,0 +1,9 @@
+using TelecomSupportSystem.BLL.DTOs.Comments;
+
+namespace TelecomSupportSystem.BLL.Services.Interfaces
+{
+    public interface IChatPusher
+    {
+        Task PushCommentAsync(int ticketId, CommentDto dto);
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ICommentService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ICommentService.cs
@@ -8,5 +8,6 @@ namespace TelecomSupportSystem.BLL.Services.Interfaces
         Task<IEnumerable<CommentDto>> GetCommentsForTicketAsync(int ticketId, int requestingUserId, string role);
         
         Task<CommentDto> AddCommentAsync(int ticketId, int userId, string role, string content);
+        Task AddSystemCommentAsync(int ticketId, string content);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationPusher.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationPusher.cs
@@ -1,0 +1,9 @@
+using TelecomSupportSystem.BLL.DTOs.Notification;
+
+namespace TelecomSupportSystem.BLL.Services.Interfaces
+{
+    public interface INotificationPusher
+    {
+        Task PushAsync(int userId, GetNotifcationDto dto);
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationService.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using TelecomSupportSystem.BLL.DTOs.Notification;
+using TelecomSupportSystem.DAL.Entities.Enums;
 
 namespace TelecomSupportSystem.BLL.Services.Interfaces
 {
     public interface INotificationService
     {
+        Task<IEnumerable<GetNotifcationDto>> GetNotificationsAsync(int userId);
+        Task MarkAsReadAsync(int notificationId, int userId);
+        Task MarkAllAsReadAsync(int userId);
+        Task SendNotificationAsync(int userId, string title, string content, NotificationType type);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/INotificationService.cs
@@ -8,6 +8,6 @@ namespace TelecomSupportSystem.BLL.Services.Interfaces
         Task<IEnumerable<GetNotifcationDto>> GetNotificationsAsync(int userId);
         Task MarkAsReadAsync(int notificationId, int userId);
         Task MarkAllAsReadAsync(int userId);
-        Task SendNotificationAsync(int userId, string title, string content, NotificationType type);
+        Task SendNotificationAsync(int userId, string title, string content, NotificationType type, int? ticketId = null);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IUserService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IUserService.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using TelecomSupportSystem.BLL.DTOs.Users;
 
 namespace TelecomSupportSystem.BLL.Services.Interfaces
 {
     public interface IUserService
     {
+        Task<AgentStatisticsDto> GetMyStatisticsAsync(int userId, string role);
+        Task<IEnumerable<RecentTicketDto>> GetRecentAssignedTicketsAsync(int userId);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/NotificationService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/NotificationService.cs
@@ -40,7 +40,7 @@ namespace TelecomSupportSystem.BLL.Services
             await _notificationRepository.MarkAllAsReadAsync(userId);
         }
 
-        public async Task SendNotificationAsync(int userId, string title, string content, NotificationType type)
+        public async Task SendNotificationAsync(int userId, string title, string content, NotificationType type, int? ticketId = null)
         {
             var notification = new Notification
             {
@@ -49,7 +49,8 @@ namespace TelecomSupportSystem.BLL.Services
                 Content = content,
                 NotificationType = type,
                 SentDate = DateTime.UtcNow,
-                IsRead = false
+                IsRead = false,
+                TicketId = ticketId
             };
 
             await _notificationRepository.CreateAsync(notification);
@@ -63,7 +64,8 @@ namespace TelecomSupportSystem.BLL.Services
             Content = n.Content,
             NotificationType = n.NotificationType.ToString(),
             SentDate = n.SentDate,
-            IsRead = n.IsRead
+            IsRead = n.IsRead,
+            TicketId = n.TicketId
         };
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/NotificationService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/NotificationService.cs
@@ -1,11 +1,69 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using TelecomSupportSystem.BLL.DTOs.Notification;
 using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities;
+using TelecomSupportSystem.DAL.Entities.Enums;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
 
 namespace TelecomSupportSystem.BLL.Services
 {
     public class NotificationService : INotificationService
     {
+        private readonly INotificationRepository _notificationRepository;
+        private readonly INotificationPusher _pusher;
+
+        public NotificationService(INotificationRepository notificationRepository, INotificationPusher pusher)
+        {
+            _notificationRepository = notificationRepository;
+            _pusher = pusher;
+        }
+
+        public async Task<IEnumerable<GetNotifcationDto>> GetNotificationsAsync(int userId)
+        {
+            var notifications = await _notificationRepository.GetByUserIdAsync(userId);
+            return notifications.Select(MapToDto);
+        }
+
+        public async Task MarkAsReadAsync(int notificationId, int userId)
+        {
+            var notification = await _notificationRepository.GetByIdAsync(notificationId)
+                ?? throw new KeyNotFoundException($"Notifikacija {notificationId} nije pronađena.");
+
+            if (notification.UserId != userId)
+                throw new UnauthorizedAccessException("Nemate pristup ovoj notifikaciji.");
+
+            notification.IsRead = true;
+            await _notificationRepository.UpdateAsync(notification);
+        }
+
+        public async Task MarkAllAsReadAsync(int userId)
+        {
+            await _notificationRepository.MarkAllAsReadAsync(userId);
+        }
+
+        public async Task SendNotificationAsync(int userId, string title, string content, NotificationType type)
+        {
+            var notification = new Notification
+            {
+                UserId = userId,
+                Title = title,
+                Content = content,
+                NotificationType = type,
+                SentDate = DateTime.UtcNow,
+                IsRead = false
+            };
+
+            await _notificationRepository.CreateAsync(notification);
+            await _pusher.PushAsync(userId, MapToDto(notification));
+        }
+
+        private static GetNotifcationDto MapToDto(Notification n) => new()
+        {
+            NotificationId = n.NotificationId,
+            Title = n.Title,
+            Content = n.Content,
+            NotificationType = n.NotificationType.ToString(),
+            SentDate = n.SentDate,
+            IsRead = n.IsRead
+        };
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
@@ -130,7 +130,8 @@ namespace TelecomSupportSystem.BLL.Services
                     ticket.CreatorId,
                     "Tiket zatvoren",
                     $"Vaš tiket \"{ticket.Title}\" je zatvoren.",
-                    NotificationType.TICKET_CLOSED);
+                    NotificationType.TICKET_CLOSED,
+                    ticket.TicketId);
         }
 
         public async Task RequestClosureAsync(int ticketId, int userId, string role)
@@ -155,7 +156,8 @@ namespace TelecomSupportSystem.BLL.Services
                 ticket.CreatorId,
                 "Promjena statusa tiketa",
                 $"Status vašeg tiketa \"{ticket.Title}\" je promijenjen na 'Čeka zatvaranje'.",
-                NotificationType.STATUS_CHANGED);
+                NotificationType.STATUS_CHANGED,
+                ticket.TicketId);
         }
 
         public async Task AcceptClosureAsync(int ticketId, int userId)
@@ -228,7 +230,8 @@ namespace TelecomSupportSystem.BLL.Services
                 ticket.CreatorId,
                 "Tiket zatvoren",
                 $"Vaš tiket \"{ticket.Title}\" je zatvoren.",
-                NotificationType.TICKET_CLOSED);
+                NotificationType.TICKET_CLOSED,
+                ticket.TicketId);
         }
 
         // PB-32: Lista tiketa filtrirana prema roli — AGENT/ADMIN vide sve, TECHNICIAN samo dodijeljene
@@ -397,7 +400,8 @@ namespace TelecomSupportSystem.BLL.Services
                 targetAgent.UserId,
                 "Tiket je proslijeđen vama",
                 $"Tiket \"{ticket.Title}\" je proslijeđen vama.",
-                NotificationType.TICKET_FORWARDED);
+                NotificationType.TICKET_FORWARDED,
+                ticket.TicketId);
 
             return newAssignment;
         }
@@ -509,7 +513,8 @@ namespace TelecomSupportSystem.BLL.Services
                 bestTech.UserId,
                 "Tiket je proslijeđen vama",
                 $"Tiket \"{ticket.Title}\" je proslijeđen vama.",
-                NotificationType.TICKET_FORWARDED);
+                NotificationType.TICKET_FORWARDED,
+                ticket.TicketId);
 
             return new AgentScoreDto
             {
@@ -579,7 +584,8 @@ namespace TelecomSupportSystem.BLL.Services
                         bestAgent.UserId,
                         "Dodijeljen vam je tiket",
                         $"Tiket \"{ticket.Title}\" vam je dodijeljen.",
-                        NotificationType.TICKET_ASSIGNED);
+                        NotificationType.TICKET_ASSIGNED,
+                        ticket.TicketId);
                 }
             }
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
@@ -14,17 +14,20 @@ namespace TelecomSupportSystem.BLL.Services
         private readonly ITeamRepository _teamRepository;
         private readonly IUserRepository _userRepository;
         private readonly INotificationService _notificationService;
+        private readonly ICommentService _commentService;
 
         public TicketService(
             ITicketRepository ticketRepository,
             ITeamRepository teamRepository,
             IUserRepository userRepository,
-            INotificationService notificationService)
+            INotificationService notificationService,
+            ICommentService commentService)
         {
             _ticketRepository    = ticketRepository;
             _teamRepository      = teamRepository;
             _userRepository      = userRepository;
             _notificationService = notificationService;
+            _commentService      = commentService;
         }
 
         // US-11: Dohvata tikete iz repozitorija i mapira ih u DTO.
@@ -403,6 +406,17 @@ namespace TelecomSupportSystem.BLL.Services
                 NotificationType.TICKET_FORWARDED,
                 ticket.TicketId);
 
+            await _commentService.AddSystemCommentAsync(
+                ticketId,
+                $"Tiket je proslijeđen agentu: {targetAgent.FirstName} {targetAgent.LastName}");
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Tiket proslijeđen",
+                $"Vaš tiket \"{ticket.Title}\" je proslijeđen drugom agentu.",
+                NotificationType.TICKET_FORWARDED,
+                ticket.TicketId);
+
             return newAssignment;
         }
 
@@ -513,6 +527,17 @@ namespace TelecomSupportSystem.BLL.Services
                 bestTech.UserId,
                 "Tiket je proslijeđen vama",
                 $"Tiket \"{ticket.Title}\" je proslijeđen vama.",
+                NotificationType.TICKET_FORWARDED,
+                ticket.TicketId);
+
+            await _commentService.AddSystemCommentAsync(
+                ticketId,
+                $"Tiket je proslijeđen tehničaru: {bestTech.FirstName} {bestTech.LastName}");
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Tiket proslijeđen",
+                $"Vaš tiket \"{ticket.Title}\" je proslijeđen tehničaru.",
                 NotificationType.TICKET_FORWARDED,
                 ticket.TicketId);
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
@@ -4,6 +4,7 @@ using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
+using NotificationType = TelecomSupportSystem.DAL.Entities.Enums.NotificationType;
 
 namespace TelecomSupportSystem.BLL.Services
 {
@@ -12,15 +13,18 @@ namespace TelecomSupportSystem.BLL.Services
         private readonly ITicketRepository _ticketRepository;
         private readonly ITeamRepository _teamRepository;
         private readonly IUserRepository _userRepository;
+        private readonly INotificationService _notificationService;
 
         public TicketService(
             ITicketRepository ticketRepository,
             ITeamRepository teamRepository,
-            IUserRepository userRepository)
+            IUserRepository userRepository,
+            INotificationService notificationService)
         {
-            _ticketRepository = ticketRepository;
-            _teamRepository   = teamRepository;
-            _userRepository   = userRepository;
+            _ticketRepository    = ticketRepository;
+            _teamRepository      = teamRepository;
+            _userRepository      = userRepository;
+            _notificationService = notificationService;
         }
 
         // US-11: Dohvata tikete iz repozitorija i mapira ih u DTO.
@@ -120,6 +124,13 @@ namespace TelecomSupportSystem.BLL.Services
             ticket.ClosedDate = DateTime.Now;
             ticket.ClosedById = userId;
             await _ticketRepository.UpdateAsync(ticket);
+
+            if (role != "CLIENT")
+                await _notificationService.SendNotificationAsync(
+                    ticket.CreatorId,
+                    "Tiket zatvoren",
+                    $"Vaš tiket \"{ticket.Title}\" je zatvoren.",
+                    NotificationType.TICKET_CLOSED);
         }
 
         public async Task RequestClosureAsync(int ticketId, int userId, string role)
@@ -139,6 +150,12 @@ namespace TelecomSupportSystem.BLL.Services
             ticket.ClosureRequestStatus = ClosureRequestStatus.PENDING;
 
             await _ticketRepository.UpdateAsync(ticket);
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Promjena statusa tiketa",
+                $"Status vašeg tiketa \"{ticket.Title}\" je promijenjen na 'Čeka zatvaranje'.",
+                NotificationType.STATUS_CHANGED);
         }
 
         public async Task AcceptClosureAsync(int ticketId, int userId)
@@ -158,6 +175,7 @@ namespace TelecomSupportSystem.BLL.Services
             ticket.ClosureRequestStatus = ClosureRequestStatus.ACCEPTED;
 
             await _ticketRepository.UpdateAsync(ticket);
+            // Klijent sam prihvata zatvaranje — ne šaljemo mu notifikaciju o vlastitoj akciji
         }
 
         public async Task RejectClosureAsync(int ticketId, int userId)
@@ -205,6 +223,12 @@ namespace TelecomSupportSystem.BLL.Services
             ticket.ClosureRequestStatus = ClosureRequestStatus.EXPIRED;
 
             await _ticketRepository.UpdateAsync(ticket);
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Tiket zatvoren",
+                $"Vaš tiket \"{ticket.Title}\" je zatvoren.",
+                NotificationType.TICKET_CLOSED);
         }
 
         // PB-32: Lista tiketa filtrirana prema roli — AGENT/ADMIN vide sve, TECHNICIAN samo dodijeljene
@@ -368,6 +392,13 @@ namespace TelecomSupportSystem.BLL.Services
                 ticket.TeamId = targetAgent.TeamId;
 
             await _ticketRepository.AddAssignmentAsync(newAssignment);
+
+            await _notificationService.SendNotificationAsync(
+                targetAgent.UserId,
+                "Tiket je proslijeđen vama",
+                $"Tiket \"{ticket.Title}\" je proslijeđen vama.",
+                NotificationType.TICKET_FORWARDED);
+
             return newAssignment;
         }
 
@@ -474,6 +505,12 @@ namespace TelecomSupportSystem.BLL.Services
 
             await _ticketRepository.AddAssignmentAsync(newAssignment);
 
+            await _notificationService.SendNotificationAsync(
+                bestTech.UserId,
+                "Tiket je proslijeđen vama",
+                $"Tiket \"{ticket.Title}\" je proslijeđen vama.",
+                NotificationType.TICKET_FORWARDED);
+
             return new AgentScoreDto
             {
                 UserId = bestTech.UserId,
@@ -537,6 +574,12 @@ namespace TelecomSupportSystem.BLL.Services
                     });
 
                     assignedAgentName = $"{bestAgent.FirstName} {bestAgent.LastName}";
+
+                    await _notificationService.SendNotificationAsync(
+                        bestAgent.UserId,
+                        "Dodijeljen vam je tiket",
+                        $"Tiket \"{ticket.Title}\" vam je dodijeljen.",
+                        NotificationType.TICKET_ASSIGNED);
                 }
             }
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/UserService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/UserService.cs
@@ -1,11 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using TelecomSupportSystem.BLL.DTOs.Users;
 using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities.Enums;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
+using Role = TelecomSupportSystem.DAL.Entities.Enums.Role;
 
 namespace TelecomSupportSystem.BLL.Services
 {
     public class UserService : IUserService
     {
+        private readonly ITicketRepository _ticketRepository;
+
+        public UserService(ITicketRepository ticketRepository)
+        {
+            _ticketRepository = ticketRepository;
+        }
+
+        public async Task<AgentStatisticsDto> GetMyStatisticsAsync(int userId, string role)
+        {
+            var tickets = await _ticketRepository.GetAssignedTicketsForStatsAsync(userId);
+            var ticketList = tickets.ToList();
+
+            var openCount = ticketList.Count(t => t.Status == TicketStatus.OPEN);
+            var closedCount = ticketList.Count(t => t.Status == TicketStatus.CLOSED);
+            var pendingCount = ticketList.Count(t => t.Status == TicketStatus.CLOSURE_REQUESTED);
+
+            // Prosječno vrijeme prvog odgovora: od kreiranja tiketa do prve poruke
+            // bilo kojeg non-CLIENT korisnika (standardna helpdesk metrika)
+            var firstResponseMinutes = ticketList
+                .Select(t =>
+                {
+                    var firstStaffComment = t.Comments
+                        .Where(c => c.Author.Role != Role.CLIENT)
+                        .OrderBy(c => c.DateTime)
+                        .FirstOrDefault();
+                    if (firstStaffComment == null) return (double?)null;
+                    return (firstStaffComment.DateTime - t.CreatedDate).TotalMinutes;
+                })
+                .Where(x => x.HasValue)
+                .Select(x => x!.Value)
+                .ToList();
+
+            double? avgFirstResponse = firstResponseMinutes.Count > 0
+                ? firstResponseMinutes.Average()
+                : null;
+
+            // Prosječno vrijeme rješavanja: od kreiranja do zatvaranja
+            var resolutionHours = ticketList
+                .Where(t => t.Status == TicketStatus.CLOSED && t.ClosedDate.HasValue)
+                .Select(t => (t.ClosedDate!.Value - t.CreatedDate).TotalHours)
+                .ToList();
+
+            double? avgResolution = resolutionHours.Count > 0
+                ? resolutionHours.Average()
+                : null;
+
+            // Prosječna ocjena — samo za agente
+            double? avgRating = null;
+            if (role == "AGENT")
+            {
+                var ratings = ticketList
+                    .Where(t => t.Rating != null)
+                    .Select(t => (double)t.Rating!.RatingValue)
+                    .ToList();
+                avgRating = ratings.Count > 0 ? ratings.Average() : null;
+            }
+
+            return new AgentStatisticsDto
+            {
+                OpenTicketsCount = openCount,
+                ClosedTicketsCount = closedCount,
+                PendingClosureCount = pendingCount,
+                AvgFirstResponseMinutes = avgFirstResponse,
+                AvgResolutionHours = avgResolution,
+                AvgRating = avgRating
+            };
+        }
+
+        public async Task<IEnumerable<RecentTicketDto>> GetRecentAssignedTicketsAsync(int userId)
+        {
+            var tickets = await _ticketRepository.GetRecentAssignedTicketsAsync(userId, 5);
+
+            return tickets.Select(t => new RecentTicketDto
+            {
+                TicketId = t.TicketId,
+                Title = t.Title,
+                Status = t.Status.ToString(),
+                Priority = t.Priority.ToString(),
+                LastActivityDate = t.Comments.Any()
+                    ? t.Comments.Max(c => c.DateTime)
+                    : t.CreatedDate
+            });
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Comment.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Comment.cs
@@ -11,10 +11,11 @@ namespace TelecomSupportSystem.DAL.Entities
         public string Content { get; set; } = string.Empty;
         public DateTime DateTime { get; set; }
         public bool IsInternal { get; set; }
-        public int AuthorId { get; set; }
+        public bool IsSystemMessage { get; set; }
+        public int? AuthorId { get; set; }
         public int TicketId { get; set; }
 
-        public User Author { get; set; } = null!;
+        public User? Author { get; set; }
         public Ticket Ticket { get; set; } = null!;
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Notification.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Entities/Notification.cs
@@ -14,6 +14,7 @@ namespace TelecomSupportSystem.DAL.Entities
         public DateTime SentDate { get; set; }
         public bool IsRead { get; set; }
         public int UserId { get; set; }
+        public int? TicketId { get; set; }
 
         public User User { get; set; } = null!;
     }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260513141525_UpdateLocationToEnum.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260513141525_UpdateLocationToEnum.cs
@@ -10,11 +10,28 @@ namespace TelecomSupportSystem.DAL.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Konvertuj postojeće string vrijednosti u odgovarajuće int vrijednosti enum-a
+            migrationBuilder.Sql(@"
+                UPDATE [Users] SET [Location] =
+                    CASE [Location]
+                        WHEN 'SARAJEVO'   THEN '0'
+                        WHEN 'BANJA_LUKA' THEN '1'
+                        WHEN 'TUZLA'      THEN '2'
+                        WHEN 'ZENICA'     THEN '3'
+                        WHEN 'MOSTAR'     THEN '4'
+                        WHEN 'BIJELJINA'  THEN '5'
+                        WHEN 'BRCKO'      THEN '6'
+                        WHEN 'BIHAC'      THEN '7'
+                        WHEN 'PRIJEDOR'   THEN '8'
+                        WHEN 'DOBOJ'      THEN '9'
+                        ELSE '0'
+                    END
+            ");
+
             migrationBuilder.AlterColumn<int>(
                 name: "Location",
                 table: "Users",
                 type: "int",
-                maxLength: 500,
                 nullable: false,
                 oldClrType: typeof(string),
                 oldType: "nvarchar(500)",

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516185745_AddTicketIdToNotification.Designer.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516185745_AddTicketIdToNotification.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelecomSupportSystem.DAL;
 
@@ -11,9 +12,11 @@ using TelecomSupportSystem.DAL;
 namespace TelecomSupportSystem.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516185745_AddTicketIdToNotification")]
+    partial class AddTicketIdToNotification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516185745_AddTicketIdToNotification.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516185745_AddTicketIdToNotification.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelecomSupportSystem.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTicketIdToNotification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TicketId",
+                table: "Notifications",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TicketId",
+                table: "Notifications");
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516192957_AddSystemCommentToComment.Designer.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516192957_AddSystemCommentToComment.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelecomSupportSystem.DAL;
 
@@ -11,9 +12,11 @@ using TelecomSupportSystem.DAL;
 namespace TelecomSupportSystem.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516192957_AddSystemCommentToComment")]
+    partial class AddSystemCommentToComment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516192957_AddSystemCommentToComment.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Migrations/20260516192957_AddSystemCommentToComment.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelecomSupportSystem.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSystemCommentToComment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorId",
+                table: "Comments",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSystemMessage",
+                table: "Comments",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSystemMessage",
+                table: "Comments");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "AuthorId",
+                table: "Comments",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/INotificationRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/INotificationRepository.cs
@@ -1,10 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using TelecomSupportSystem.DAL.Entities;
 
 namespace TelecomSupportSystem.DAL.Repositories.Interfaces
 {
     public interface INotificationRepository
     {
+        Task<IEnumerable<Notification>> GetByUserIdAsync(int userId);
+        Task<Notification?> GetByIdAsync(int notificationId);
+        Task CreateAsync(Notification notification);
+        Task UpdateAsync(Notification notification);
+        Task MarkAllAsReadAsync(int userId);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/ITicketRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/ITicketRepository.cs
@@ -30,5 +30,11 @@ namespace TelecomSupportSystem.DAL.Repositories.Interfaces
         Task AddAssignmentAsync(TicketUser assignment);
 
         Task UpdateAsync(Ticket ticket);
+
+        // PB-42: Svi tiketi gdje je korisnik posljednji dodjeljeni (svi statusi), s komentarima i ocjenama
+        Task<IEnumerable<Ticket>> GetAssignedTicketsForStatsAsync(int userId);
+
+        // Dashboard: N najrecentnijih tiketa sortiranih po zadnjoj aktivnosti
+        Task<IEnumerable<Ticket>> GetRecentAssignedTicketsAsync(int userId, int count);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/NotificationRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/NotificationRepository.cs
@@ -1,11 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using Microsoft.EntityFrameworkCore;
+using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
 
 namespace TelecomSupportSystem.DAL.Repositories
 {
     public class NotificationRepository : INotificationRepository
     {
+        private readonly ApplicationDbContext _context;
+
+        public NotificationRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Notification>> GetByUserIdAsync(int userId)
+        {
+            return await _context.Notifications
+                .Where(n => n.UserId == userId)
+                .OrderByDescending(n => n.SentDate)
+                .ToListAsync();
+        }
+
+        public async Task<Notification?> GetByIdAsync(int notificationId)
+        {
+            return await _context.Notifications.FindAsync(notificationId);
+        }
+
+        public async Task CreateAsync(Notification notification)
+        {
+            _context.Notifications.Add(notification);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Notification notification)
+        {
+            _context.Notifications.Update(notification);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task MarkAllAsReadAsync(int userId)
+        {
+            await _context.Notifications
+                .Where(n => n.UserId == userId && !n.IsRead)
+                .ExecuteUpdateAsync(s => s.SetProperty(n => n.IsRead, true));
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/TicketRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/TicketRepository.cs
@@ -115,5 +115,49 @@ namespace TelecomSupportSystem.DAL.Repositories
             _context.Tickets.Update(ticket);
             await _context.SaveChangesAsync();
         }
+
+        // Dashboard: N najrecentnijih tiketa po zadnjoj aktivnosti (komentar ili kreiranje)
+        public async Task<IEnumerable<Ticket>> GetRecentAssignedTicketsAsync(int userId, int count)
+        {
+            var latestAssignedIds = await _context.Set<TicketUser>()
+                .Where(tu => tu.UserId == userId &&
+                             !_context.Set<TicketUser>().Any(tu2 =>
+                                 tu2.TicketId == tu.TicketId &&
+                                 tu2.AssignmentDate > tu.AssignmentDate))
+                .Select(tu => tu.TicketId)
+                .ToListAsync();
+
+            var tickets = await _context.Tickets
+                .Where(t => latestAssignedIds.Contains(t.TicketId))
+                .Include(t => t.Comments)
+                .ToListAsync();
+
+            return tickets
+                .OrderByDescending(t => t.Comments.Any()
+                    ? t.Comments.Max(c => c.DateTime)
+                    : t.CreatedDate)
+                .Take(count)
+                .ToList();
+        }
+
+        // PB-42: Tiketi gdje je korisnik posljednji dodjeljeni (svi statusi), s komentarima i ocjenama
+        public async Task<IEnumerable<Ticket>> GetAssignedTicketsForStatsAsync(int userId)
+        {
+            var latestAssignedIds = await _context.Set<TicketUser>()
+                .Where(tu => tu.UserId == userId &&
+                             !_context.Set<TicketUser>().Any(tu2 =>
+                                 tu2.TicketId == tu.TicketId &&
+                                 tu2.AssignmentDate > tu.AssignmentDate))
+                .Select(tu => tu.TicketId)
+                .ToListAsync();
+
+            return await _context.Tickets
+                .Where(t => latestAssignedIds.Contains(t.TicketId))
+                .Include(t => t.Comments)
+                    .ThenInclude(c => c.Author)
+                .Include(t => t.Rating)
+                .Include(t => t.Creator)
+                .ToListAsync();
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Communication/CommentServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Communication/CommentServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
@@ -12,11 +13,12 @@ namespace TelecomSupportSystem.Tests.Communication
     {
         private readonly Mock<ICommentRepository> _commentRepoMock = new();
         private readonly Mock<ITicketRepository> _ticketRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
         private readonly CommentService _service;
 
         public CommentServiceTests()
         {
-            _service = new CommentService(_commentRepoMock.Object, _ticketRepoMock.Object);
+            _service = new CommentService(_commentRepoMock.Object, _ticketRepoMock.Object, _notificationServiceMock.Object);
         }
 
         private static User MakeUser(int id = 1, Role role = Role.CLIENT) => new()

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Communication/CommentServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Communication/CommentServiceTests.cs
@@ -18,7 +18,7 @@ namespace TelecomSupportSystem.Tests.Communication
 
         public CommentServiceTests()
         {
-            _service = new CommentService(_commentRepoMock.Object, _ticketRepoMock.Object, _notificationServiceMock.Object);
+            _service = new CommentService(_commentRepoMock.Object, _ticketRepoMock.Object, _notificationServiceMock.Object, new Mock<IChatPusher>().Object);
         }
 
         private static User MakeUser(int id = 1, Role role = Role.CLIENT) => new()

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/DataIntegrity/AutoAssignDataIntegrityTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/DataIntegrity/AutoAssignDataIntegrityTests.cs
@@ -2,10 +2,12 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -26,7 +28,8 @@ namespace TelecomSupportSystem.Tests.DataIntegrity
             var controller = new TicketController(new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context)));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/DataIntegrity/AutoAssignDataIntegrityTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/DataIntegrity/AutoAssignDataIntegrityTests.cs
@@ -29,7 +29,7 @@ namespace TelecomSupportSystem.Tests.DataIntegrity
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AllTicketsIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AllTicketsIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role)
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AllTicketsIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AllTicketsIntegrationTests.cs
@@ -2,11 +2,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -26,7 +28,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role)
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context));
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AutoAssignIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AutoAssignIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace TelecomSupportSystem.Tests.Integration
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object);
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AutoAssignIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/AutoAssignIntegrationTests.cs
@@ -2,11 +2,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -29,7 +31,8 @@ namespace TelecomSupportSystem.Tests.Integration
             var service = new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/CommentIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/CommentIntegrationTests.cs
@@ -9,6 +9,7 @@ using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.API.Hubs;
 using TelecomSupportSystem.BLL.DTOs.Comments;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -30,7 +31,7 @@ namespace TelecomSupportSystem.Tests.Integration
         {
             var ticketRepo = new TicketRepository(context);
             var commentRepo = new CommentRepository(context);
-            var service = new CommentService(commentRepo, ticketRepo);
+            var service = new CommentService(commentRepo, ticketRepo, new Mock<INotificationService>().Object);
             var controller = new CommentController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/CommentIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/CommentIntegrationTests.cs
@@ -31,7 +31,7 @@ namespace TelecomSupportSystem.Tests.Integration
         {
             var ticketRepo = new TicketRepository(context);
             var commentRepo = new CommentRepository(context);
-            var service = new CommentService(commentRepo, ticketRepo, new Mock<INotificationService>().Object);
+            var service = new CommentService(commentRepo, ticketRepo, new Mock<INotificationService>().Object, new Mock<IChatPusher>().Object);
             var controller = new CommentController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketDetailIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketDetailIntegrationTests.cs
@@ -2,10 +2,12 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -25,7 +27,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role)
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context));
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketDetailIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketDetailIntegrationTests.cs
@@ -27,7 +27,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role)
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketIntegrationTests.cs
@@ -2,11 +2,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -26,7 +28,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role = "CLIENT")
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context));
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/TicketIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace TelecomSupportSystem.Tests.Integration
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role = "CLIENT")
         {
             var repo = new TicketRepository(context);
-            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object);
+            var service = new TicketService(repo, new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object);
             var controller = new TicketController(service);
 
             var claims = new List<Claim>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AllTicketsPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AllTicketsPerformanceTests.cs
@@ -3,11 +3,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -56,7 +58,7 @@ namespace TelecomSupportSystem.Tests.Performance
             }
             await context.SaveChangesAsync();
 
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context)));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AllTicketsPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AllTicketsPerformanceTests.cs
@@ -58,7 +58,7 @@ namespace TelecomSupportSystem.Tests.Performance
             }
             await context.SaveChangesAsync();
 
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AutoAssignPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AutoAssignPerformanceTests.cs
@@ -3,10 +3,12 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -31,7 +33,8 @@ namespace TelecomSupportSystem.Tests.Performance
             var controller = new TicketController(new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context)));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object));
 
             var claims = new List<Claim>
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AutoAssignPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/AutoAssignPerformanceTests.cs
@@ -34,7 +34,7 @@ namespace TelecomSupportSystem.Tests.Performance
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
 
             var claims = new List<Claim>
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/CommentPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/CommentPerformanceTests.cs
@@ -87,7 +87,7 @@ namespace TelecomSupportSystem.Tests.Performance
             await context.SaveChangesAsync();
 
             var controller = new CommentController(
-                new CommentService(new CommentRepository(context), new TicketRepository(context), new Mock<INotificationService>().Object));
+                new CommentService(new CommentRepository(context), new TicketRepository(context), new Mock<INotificationService>().Object, new Mock<IChatPusher>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/CommentPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/CommentPerformanceTests.cs
@@ -10,6 +10,7 @@ using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.API.Hubs;
 using TelecomSupportSystem.BLL.DTOs.Comments;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -86,7 +87,7 @@ namespace TelecomSupportSystem.Tests.Performance
             await context.SaveChangesAsync();
 
             var controller = new CommentController(
-                new CommentService(new CommentRepository(context), new TicketRepository(context)));
+                new CommentService(new CommentRepository(context), new TicketRepository(context), new Mock<INotificationService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/Scale/AutoAssignScalePerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/Scale/AutoAssignScalePerformanceTests.cs
@@ -3,10 +3,12 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -29,7 +31,8 @@ namespace TelecomSupportSystem.Tests.Performance.Scale
             var controller = new TicketController(new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context)));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/Scale/AutoAssignScalePerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/Scale/AutoAssignScalePerformanceTests.cs
@@ -32,7 +32,7 @@ namespace TelecomSupportSystem.Tests.Performance.Scale
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketDetailPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketDetailPerformanceTests.cs
@@ -57,7 +57,7 @@ namespace TelecomSupportSystem.Tests.Performance
             });
             await context.SaveChangesAsync();
 
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketDetailPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketDetailPerformanceTests.cs
@@ -3,9 +3,11 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -55,7 +57,7 @@ namespace TelecomSupportSystem.Tests.Performance
             });
             await context.SaveChangesAsync();
 
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context)));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, "1"),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketPerformanceTests.cs
@@ -31,7 +31,7 @@ namespace TelecomSupportSystem.Tests.Performance
 
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role = "CLIENT")
         {
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, userId.ToString()),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketPerformanceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Performance/TicketPerformanceTests.cs
@@ -3,11 +3,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -29,7 +31,7 @@ namespace TelecomSupportSystem.Tests.Performance
 
         private static TicketController CreateController(ApplicationDbContext context, int userId, string role = "CLIENT")
         {
-            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context)));
+            var controller = new TicketController(new TicketService(new TicketRepository(context), new TeamRepository(context), new UserRepository(context), new Mock<INotificationService>().Object));
             var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, userId.ToString()),

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Security/AutoAssignSecurityTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Security/AutoAssignSecurityTests.cs
@@ -29,7 +29,7 @@ namespace TelecomSupportSystem.Tests.Security
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Security/AutoAssignSecurityTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Security/AutoAssignSecurityTests.cs
@@ -2,10 +2,12 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 using TelecomSupportSystem.API.Controllers;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -26,7 +28,8 @@ namespace TelecomSupportSystem.Tests.Security
             var controller = new TicketController(new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context)));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object));
 
             controller.ControllerContext = new ControllerContext
             {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Services/EmptyServicesTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Services/EmptyServicesTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
+using Moq;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
 using Xunit;
 
 namespace TelecomSupportSystem.Tests.Services
@@ -10,11 +13,13 @@ namespace TelecomSupportSystem.Tests.Services
         public void Constructor_ShouldInitializeSuccessfully()
         {
             // Arrange & Act
-            var service = new NotificationService();
+            var service = new NotificationService(
+                new Mock<INotificationRepository>().Object,
+                new Mock<INotificationPusher>().Object);
 
             // Assert
             service.Should().NotBeNull();
-            service.Should().BeAssignableTo<TelecomSupportSystem.BLL.Services.Interfaces.INotificationService>();
+            service.Should().BeAssignableTo<INotificationService>();
         }
     }
 
@@ -38,7 +43,7 @@ namespace TelecomSupportSystem.Tests.Services
         public void Constructor_ShouldInitializeSuccessfully()
         {
             // Arrange & Act
-            var service = new UserService();
+            var service = new UserService(new Mock<ITicketRepository>().Object);
 
             // Assert
             service.Should().NotBeNull();

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/System/Sprint7UserStoriesSystemTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/System/Sprint7UserStoriesSystemTests.cs
@@ -11,6 +11,7 @@ using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Comments;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
@@ -31,7 +32,8 @@ namespace TelecomSupportSystem.Tests.System
             var controller = new TicketController(new TicketService(
                 new TicketRepository(context),
                 new TeamRepository(context),
-                new UserRepository(context)));
+                new UserRepository(context),
+                new Mock<INotificationService>().Object));
 
             SetUser(controller, userId, role);
             return controller;
@@ -41,7 +43,8 @@ namespace TelecomSupportSystem.Tests.System
         {
             var controller = new CommentController(new CommentService(
                 new CommentRepository(context),
-                new TicketRepository(context)));
+                new TicketRepository(context),
+                new Mock<INotificationService>().Object));
 
             SetUser(controller, userId, role);
             return controller;

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/System/Sprint7UserStoriesSystemTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/System/Sprint7UserStoriesSystemTests.cs
@@ -33,7 +33,7 @@ namespace TelecomSupportSystem.Tests.System
                 new TicketRepository(context),
                 new TeamRepository(context),
                 new UserRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<ICommentService>().Object));
 
             SetUser(controller, userId, role);
             return controller;
@@ -44,7 +44,7 @@ namespace TelecomSupportSystem.Tests.System
             var controller = new CommentController(new CommentService(
                 new CommentRepository(context),
                 new TicketRepository(context),
-                new Mock<INotificationService>().Object));
+                new Mock<INotificationService>().Object, new Mock<IChatPusher>().Object));
 
             SetUser(controller, userId, role);
             return controller;

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AllTicketsServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AllTicketsServiceTests.cs
@@ -19,7 +19,7 @@ namespace TelecomSupportSystem.Tests.Tickets
 
         public AllTicketsServiceTests()
         {
-            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
+            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object, new Mock<ICommentService>().Object);
         }
 
         private static Ticket MakeTicket(int id = 1, int creatorId = 5) => new()

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AllTicketsServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AllTicketsServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
@@ -13,11 +14,12 @@ namespace TelecomSupportSystem.Tests.Tickets
         private readonly Mock<ITicketRepository> _repoMock = new();
         private readonly Mock<ITeamRepository> _teamRepoMock = new();
         private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
         private readonly TicketService _service;
 
         public AllTicketsServiceTests()
         {
-            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object);
+            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
         }
 
         private static Ticket MakeTicket(int id = 1, int creatorId = 5) => new()

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AutoAssignServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AutoAssignServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Moq;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
@@ -21,11 +22,12 @@ namespace TelecomSupportSystem.Tests.Tickets
         private readonly Mock<ITicketRepository> _ticketRepoMock = new();
         private readonly Mock<ITeamRepository> _teamRepoMock = new();
         private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
         private readonly TicketService _service;
 
         public AutoAssignServiceTests()
         {
-            _service = new TicketService(_ticketRepoMock.Object, _teamRepoMock.Object, _userRepoMock.Object);
+            _service = new TicketService(_ticketRepoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
 
             _ticketRepoMock
                 .Setup(r => r.CreateAsync(It.IsAny<Ticket>()))

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AutoAssignServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/AutoAssignServiceTests.cs
@@ -27,7 +27,7 @@ namespace TelecomSupportSystem.Tests.Tickets
 
         public AutoAssignServiceTests()
         {
-            _service = new TicketService(_ticketRepoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
+            _service = new TicketService(_ticketRepoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object, new Mock<ICommentService>().Object);
 
             _ticketRepoMock
                 .Setup(r => r.CreateAsync(It.IsAny<Ticket>()))

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketDetailServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketDetailServiceTests.cs
@@ -19,7 +19,7 @@ namespace TelecomSupportSystem.Tests.Tickets
 
         public TicketDetailServiceTests()
         {
-            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
+            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object, new Mock<ICommentService>().Object);
         }
 
         private static User MakeUser(int id = 1, string first = "Amir", string last = "Hadzic", Role role = Role.CLIENT) =>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketDetailServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketDetailServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
@@ -13,11 +14,12 @@ namespace TelecomSupportSystem.Tests.Tickets
         private readonly Mock<ITicketRepository> _repoMock = new();
         private readonly Mock<ITeamRepository> _teamRepoMock = new();
         private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
         private readonly TicketService _service;
 
         public TicketDetailServiceTests()
         {
-            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object);
+            _service = new TicketService(_repoMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
         }
 
         private static User MakeUser(int id = 1, string first = "Amir", string last = "Hadzic", Role role = Role.CLIENT) =>

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketServiceTests.cs
@@ -21,7 +21,7 @@ namespace TelecomSupportSystem.Tests.Tickets
 
         public TicketServiceTests()
         {
-            _ticketService = new TicketService(_ticketRepositoryMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
+            _ticketService = new TicketService(_ticketRepositoryMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object, new Mock<ICommentService>().Object);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketServiceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using TelecomSupportSystem.BLL.DTOs;
 using TelecomSupportSystem.BLL.DTOs.Tickets;
 using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
 using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Entities.Enums;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
@@ -15,11 +16,12 @@ namespace TelecomSupportSystem.Tests.Tickets
         private readonly Mock<ITicketRepository> _ticketRepositoryMock = new();
         private readonly Mock<ITeamRepository> _teamRepoMock = new();
         private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
         private readonly TicketService _ticketService;
 
         public TicketServiceTests()
         {
-            _ticketService = new TicketService(_ticketRepositoryMock.Object, _teamRepoMock.Object, _userRepoMock.Object);
+            _ticketService = new TicketService(_ticketRepositoryMock.Object, _teamRepoMock.Object, _userRepoMock.Object, _notificationServiceMock.Object);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/Project/frontend/src/App.jsx
+++ b/Project/frontend/src/App.jsx
@@ -1,5 +1,6 @@
-﻿import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext'
+import { NotificationProvider } from './context/NotificationContext'
 import AppLayout from './components/layout/AppLayout'
 import ProtectedRoute from './components/layout/ProtectedRoute'
 
@@ -12,6 +13,8 @@ import AssignedTickets from './pages/AssignedTickets'
 import CreateTicket from './pages/CreateTicket'
 import Faq from './pages/Faq'
 import TicketDetail from './pages/TicketDetail'
+import Statistics from './pages/Statistics'
+import Notifications from './pages/Notifications'
 
 function AppRoutes() {
   const { user } = useAuth()
@@ -39,6 +42,8 @@ function AppRoutes() {
         <Route path="/assigned" element={<AssignedTickets />} />
         <Route path="/create-ticket" element={<CreateTicket />} />
         <Route path="/faq" element={<Faq />} />
+        <Route path="/statistics" element={<Statistics />} />
+        <Route path="/notifications" element={<Notifications />} />
       </Route>
 
       <Route path="*" element={<Navigate to={user ? '/dashboard' : '/login'} replace />} />
@@ -50,7 +55,9 @@ export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <AppRoutes />
+        <NotificationProvider>
+          <AppRoutes />
+        </NotificationProvider>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/Project/frontend/src/components/layout/Header.jsx
+++ b/Project/frontend/src/components/layout/Header.jsx
@@ -1,7 +1,43 @@
-import PropTypes from 'prop-types';
-import { Menu, Bell } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import { Bell, Menu, X } from 'lucide-react'
+import { useNotifications } from '../../context/NotificationContext'
+
+function timeAgo(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'upravo'
+  if (m < 60) return `prije ${m} min`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `prije ${h}h`
+  const d = Math.floor(h / 24)
+  return `prije ${d}d`
+}
 
 export default function Header({ onMenuToggle, title }) {
+  const navigate = useNavigate()
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications()
+  const [open, setOpen] = useState(false)
+  const dropdownRef = useRef(null)
+
+  const preview = notifications.slice(0, 5)
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  async function handleNotificationClick(n) {
+    if (!n.isRead) await markAsRead(n.notificationId)
+    setOpen(false)
+  }
+
   return (
     <header className="sticky top-0 z-30 bg-white border-b border-gray-200 px-4 lg:px-6 py-3">
       <div className="flex items-center justify-between">
@@ -15,17 +51,91 @@ export default function Header({ onMenuToggle, title }) {
           <h1 className="text-lg font-semibold text-gray-900">{title}</h1>
         </div>
 
-        <div className="flex items-center gap-3">
-          <button className="relative p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100">
-            <Bell size={20} />
-          </button>
+        <div className="flex items-center gap-3" ref={dropdownRef}>
+          {/* Bell button */}
+          <div className="relative">
+            <button
+              onClick={() => setOpen((o) => !o)}
+              className="relative p-2 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            >
+              <Bell size={20} />
+              {unreadCount > 0 && (
+                <span className="absolute top-1 right-1 w-4 h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none">
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
+            </button>
+
+            {/* Dropdown */}
+            {open && (
+              <div className="absolute right-0 mt-1 w-80 bg-white rounded-xl shadow-lg border border-gray-100 z-50 overflow-hidden">
+                {/* Header */}
+                <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+                  <span className="text-sm font-semibold text-gray-900">Notifikacije</span>
+                  <div className="flex items-center gap-2">
+                    {unreadCount > 0 && (
+                      <button
+                        onClick={markAllAsRead}
+                        className="text-xs text-navy-600 hover:underline"
+                      >
+                        Označi sve kao pročitano
+                      </button>
+                    )}
+                    <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600">
+                      <X size={14} />
+                    </button>
+                  </div>
+                </div>
+
+                {/* List */}
+                {preview.length === 0 ? (
+                  <div className="px-4 py-6 text-center text-sm text-gray-400">
+                    Nema notifikacija.
+                  </div>
+                ) : (
+                  <ul>
+                    {preview.map((n) => (
+                      <li
+                        key={n.notificationId}
+                        onClick={() => handleNotificationClick(n)}
+                        className={`px-4 py-3 border-b border-gray-50 last:border-0 cursor-pointer hover:bg-gray-50 transition-colors ${
+                          !n.isRead ? 'bg-blue-50/60' : ''
+                        }`}
+                      >
+                        <div className="flex items-start gap-2">
+                          {!n.isRead && (
+                            <span className="mt-1.5 w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+                          )}
+                          <div className={!n.isRead ? '' : 'ml-4'}>
+                            <p className="text-sm font-medium text-gray-900">{n.title}</p>
+                            <p className="text-xs text-gray-500 mt-0.5">{n.content}</p>
+                            <p className="text-xs text-gray-400 mt-1">{timeAgo(n.sentDate)}</p>
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {/* Footer */}
+                <div className="px-4 py-2 border-t border-gray-100 text-center">
+                  <button
+                    onClick={() => { setOpen(false); navigate('/notifications') }}
+                    className="text-xs text-navy-600 hover:underline"
+                  >
+                    Pogledaj sve notifikacije
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </header>
-  );
+  )
 }
 
 Header.propTypes = {
   onMenuToggle: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-};
+}

--- a/Project/frontend/src/components/layout/Header.jsx
+++ b/Project/frontend/src/components/layout/Header.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Bell, Menu, X } from 'lucide-react'
+import { useAuth } from '../../context/AuthContext'
 import { useNotifications } from '../../context/NotificationContext'
 
 function timeAgo(dateStr) {
@@ -17,7 +18,12 @@ function timeAgo(dateStr) {
 
 export default function Header({ onMenuToggle, title }) {
   const navigate = useNavigate()
+  const { user } = useAuth()
   const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications()
+
+  function ticketPath(ticketId) {
+    return user?.role === 'CLIENT' ? `/mytickets/${ticketId}` : `/tickets/${ticketId}`
+  }
   const [open, setOpen] = useState(false)
   const dropdownRef = useRef(null)
 
@@ -36,7 +42,7 @@ export default function Header({ onMenuToggle, title }) {
   async function handleNotificationClick(n) {
     if (!n.isRead) await markAsRead(n.notificationId)
     setOpen(false)
-    // TODO: navigiraj na odgovarajući tiket (potrebno dodati ticketId u Notification entitet i DTO)
+    if (n.ticketId) navigate(ticketPath(n.ticketId))
   }
 
   return (

--- a/Project/frontend/src/components/layout/Header.jsx
+++ b/Project/frontend/src/components/layout/Header.jsx
@@ -36,6 +36,7 @@ export default function Header({ onMenuToggle, title }) {
   async function handleNotificationClick(n) {
     if (!n.isRead) await markAsRead(n.notificationId)
     setOpen(false)
+    // TODO: navigiraj na odgovarajući tiket (potrebno dodati ticketId u Notification entitet i DTO)
   }
 
   return (

--- a/Project/frontend/src/components/layout/Sidebar.jsx
+++ b/Project/frontend/src/components/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { useNotifications } from '../../context/NotificationContext';
 import {
   LayoutDashboard,
   Ticket,
@@ -9,6 +10,8 @@ import {
   Headphones,
   PlusCircle,
   HelpCircle,
+  BarChart2,
+  Bell,
 } from 'lucide-react';
 
 const navConfig = {
@@ -17,27 +20,34 @@ const navConfig = {
     { to: '/mytickets', label: 'Moji tiketi', icon: Ticket },
     { to: '/create-ticket', label: 'Kreiraj tiket', icon: PlusCircle },
     { to: '/faq', label: 'FAQ', icon: HelpCircle },
+    { to: '/notifications', label: 'Notifikacije', icon: Bell },
   ],
   AGENT: [
     { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { to: '/tickets', label: 'Svi tiketi', icon: Ticket },
     { to: '/assigned', label: 'Dodijeljeni meni', icon: Ticket },
+    { to: '/statistics', label: 'Moja statistika', icon: BarChart2 },
     { to: '/faq', label: 'FAQ', icon: HelpCircle },
+    { to: '/notifications', label: 'Notifikacije', icon: Bell },
   ],
   TECHNICIAN: [
     { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { to: '/assigned', label: 'Dodijeljeni meni', icon: Ticket },
+    { to: '/statistics', label: 'Moja statistika', icon: BarChart2 },
+    { to: '/notifications', label: 'Notifikacije', icon: Bell },
   ],
   ADMINISTRATOR: [
     { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { to: '/tickets', label: 'Svi tiketi', icon: Ticket },
     { to: '/faq', label: 'FAQ', icon: HelpCircle },
+    { to: '/notifications', label: 'Notifikacije', icon: Bell },
   ],
 };
 
 export default function Sidebar({ isOpen, onClose }) {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const { unreadCount } = useNotifications();
   const links = navConfig[user?.role] || [];
 
   const handleLogout = async () => {
@@ -101,7 +111,12 @@ export default function Sidebar({ isOpen, onClose }) {
               }
             >
               <link.icon size={18} />
-              {link.label}
+              <span className="flex-1">{link.label}</span>
+              {link.to === '/notifications' && unreadCount > 0 && (
+                <span className="min-w-[18px] h-[18px] px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none">
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
             </NavLink>
           ))}
         </nav>

--- a/Project/frontend/src/context/NotificationContext.jsx
+++ b/Project/frontend/src/context/NotificationContext.jsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { useAuth } from './AuthContext'
+import {
+  getNotifications,
+  markAsRead as apiMarkAsRead,
+  markAllAsRead as apiMarkAllAsRead,
+  createNotificationConnection,
+} from '../services/notificationService'
+
+const NotificationContext = createContext(null)
+
+export function NotificationProvider({ children }) {
+  const { user } = useAuth()
+  const [notifications, setNotifications] = useState([])
+  const connectionRef = useRef(null)
+
+  const unreadCount = notifications.filter((n) => !n.isRead).length
+
+  const load = useCallback(async () => {
+    if (!user) return
+    try {
+      const data = await getNotifications()
+      setNotifications(data)
+    } catch {
+      // ignore — user may not be authenticated yet
+    }
+  }, [user])
+
+  useEffect(() => {
+    if (!user) {
+      setNotifications([])
+      return
+    }
+
+    load()
+
+    const connection = createNotificationConnection()
+    connectionRef.current = connection
+
+    connection.on('ReceiveNotification', (notification) => {
+      setNotifications((prev) => [notification, ...prev])
+    })
+
+    connection
+      .start()
+      .then(() => connection.invoke('JoinUserGroup', String(user.userId)))
+      .catch(() => {})
+
+    return () => {
+      connection.stop()
+    }
+  }, [user, load])
+
+  const markAsRead = useCallback(async (notificationId) => {
+    await apiMarkAsRead(notificationId)
+    setNotifications((prev) =>
+      prev.map((n) => (n.notificationId === notificationId ? { ...n, isRead: true } : n))
+    )
+  }, [])
+
+  const markAllAsRead = useCallback(async () => {
+    await apiMarkAllAsRead()
+    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })))
+  }, [])
+
+  return (
+    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead, reload: load }}>
+      {children}
+    </NotificationContext.Provider>
+  )
+}
+
+NotificationProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useNotifications() {
+  return useContext(NotificationContext)
+}

--- a/Project/frontend/src/context/NotificationContext.jsx
+++ b/Project/frontend/src/context/NotificationContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react'
+import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useAuth } from './AuthContext'
 import {
@@ -15,25 +15,21 @@ export function NotificationProvider({ children }) {
   const [notifications, setNotifications] = useState([])
   const connectionRef = useRef(null)
 
-  const unreadCount = notifications.filter((n) => !n.isRead).length
-
-  const load = useCallback(async () => {
+  // Exposed as `reload` so consumers can manually refresh
+  const load = useCallback(() => {
     if (!user) return
-    try {
-      const data = await getNotifications()
-      setNotifications(data)
-    } catch {
-      // ignore — user may not be authenticated yet
-    }
+    getNotifications()
+      .then((data) => setNotifications(data))
+      .catch(() => {})
   }, [user])
 
   useEffect(() => {
-    if (!user) {
-      setNotifications([])
-      return
-    }
+    if (!user) return
 
-    load()
+    // setState happens inside .then() callback — not synchronously in the effect body
+    getNotifications()
+      .then((data) => setNotifications(data))
+      .catch(() => {})
 
     const connection = createNotificationConnection()
     connectionRef.current = connection
@@ -50,7 +46,7 @@ export function NotificationProvider({ children }) {
     return () => {
       connection.stop()
     }
-  }, [user, load])
+  }, [user])
 
   const markAsRead = useCallback(async (notificationId) => {
     await apiMarkAsRead(notificationId)
@@ -64,8 +60,19 @@ export function NotificationProvider({ children }) {
     setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })))
   }, [])
 
+  const value = useMemo(() => {
+    const activeNotifications = user ? notifications : []
+    return {
+      notifications: activeNotifications,
+      unreadCount: activeNotifications.filter((n) => !n.isRead).length,
+      markAsRead,
+      markAllAsRead,
+      reload: load,
+    }
+  }, [user, notifications, markAsRead, markAllAsRead, load])
+
   return (
-    <NotificationContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead, reload: load }}>
+    <NotificationContext.Provider value={value}>
       {children}
     </NotificationContext.Provider>
   )

--- a/Project/frontend/src/pages/Dashboard.jsx
+++ b/Project/frontend/src/pages/Dashboard.jsx
@@ -54,7 +54,8 @@ function timeAgo(dateStr) {
 
 // ---------- sub-components ----------
 
-function QuickCard({ icon: Icon, label, description, to, color }) {
+function QuickCard({ icon, label, description, to, color }) {
+  const Icon = icon
   const navigate = useNavigate()
   return (
     <div
@@ -84,7 +85,8 @@ function QuickCard({ icon: Icon, label, description, to, color }) {
   )
 }
 
-function MiniStat({ icon: Icon, label, value, color }) {
+function MiniStat({ icon, label, value, color }) {
+  const Icon = icon
   return (
     <div className="bg-white rounded-lg px-4 py-3 shadow-sm border border-gray-100 flex items-center gap-3">
       <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${color}`}>

--- a/Project/frontend/src/pages/Dashboard.jsx
+++ b/Project/frontend/src/pages/Dashboard.jsx
@@ -1,17 +1,78 @@
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
-import { Ticket, PlusCircle, LayoutDashboard } from 'lucide-react'
+import { getMyStatistics, getMyRecentTickets } from '../services/userService'
+import {
+  Ticket,
+  PlusCircle,
+  LayoutDashboard,
+  BarChart2,
+  CheckCircle,
+  AlertCircle,
+  MessageSquare,
+  Clock,
+  Star,
+  ChevronRight,
+  Loader2,
+} from 'lucide-react'
+import Badge from '../components/common/Badge'
+
+// ---------- helpers ----------
+
+function formatMinutes(minutes) {
+  if (minutes == null) return '—'
+  if (minutes < 60) return `${Math.round(minutes)} min`
+  const h = Math.floor(minutes / 60)
+  const m = Math.round(minutes % 60)
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}
+
+function formatHours(hours) {
+  if (hours == null) return '—'
+  if (hours < 1) return `${Math.round(hours * 60)} min`
+  if (hours < 24) return `${hours.toFixed(1)}h`
+  const d = Math.floor(hours / 24)
+  const h = Math.round(hours % 24)
+  return h > 0 ? `${d}d ${h}h` : `${d}d`
+}
+
+function formatRating(rating) {
+  if (rating == null) return '—'
+  return `${rating.toFixed(1)} / 5`
+}
+
+function timeAgo(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'upravo'
+  if (m < 60) return `prije ${m} min`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `prije ${h}h`
+  const d = Math.floor(h / 24)
+  return `prije ${d}d`
+}
+
+// ---------- sub-components ----------
 
 function QuickCard({ icon: Icon, label, description, to, color }) {
   const navigate = useNavigate()
-  void Icon;
   return (
     <div
       onClick={() => navigate(to)}
-      className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
+      className="bg-white rounded-xl shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
     >
-      <div className="flex items-center gap-4">
-        <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${color}`}>
+      {/* Mobile: compact row — icon + label + chevron */}
+      <div className="flex sm:hidden items-center gap-3 px-4 py-3">
+        <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${color}`}>
+          <Icon size={16} className="text-white" />
+        </div>
+        <span className="text-sm font-semibold text-gray-900 flex-1">{label}</span>
+        <ChevronRight size={14} className="text-gray-300 flex-shrink-0" />
+      </div>
+
+      {/* sm+: full card — icon + label + description */}
+      <div className="hidden sm:flex items-center gap-4 p-5">
+        <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${color}`}>
           <Icon size={22} className="text-white" />
         </div>
         <div>
@@ -23,25 +84,105 @@ function QuickCard({ icon: Icon, label, description, to, color }) {
   )
 }
 
+function MiniStat({ icon: Icon, label, value, color }) {
+  return (
+    <div className="bg-white rounded-lg px-4 py-3 shadow-sm border border-gray-100 flex items-center gap-3">
+      <div className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${color}`}>
+        <Icon size={15} className="text-white" />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs text-gray-400 truncate">{label}</p>
+        <p className="text-sm font-bold text-gray-900 truncate">{value}</p>
+      </div>
+    </div>
+  )
+}
+
+function RecentTicketRow({ ticket }) {
+  const navigate = useNavigate()
+  return (
+    <div
+      onClick={() => navigate(`/tickets/${ticket.ticketId}`)}
+      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors border-b border-gray-50 last:border-0"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">{ticket.title}</p>
+        <p className="text-xs text-gray-400 mt-0.5">{timeAgo(ticket.lastActivityDate)}</p>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <Badge value={ticket.status} />
+        <Badge value={ticket.priority} />
+      </div>
+      <ChevronRight size={14} className="text-gray-300 flex-shrink-0" />
+    </div>
+  )
+}
+
+// ---------- main component ----------
+
 export default function Dashboard() {
   const { user } = useAuth()
+  const isStaff = user?.role === 'AGENT' || user?.role === 'TECHNICIAN'
 
+  const [stats, setStats] = useState(null)
+  const [recentTickets, setRecentTickets] = useState([])
+  const [loadingStats, setLoadingStats] = useState(isStaff)
+  const [loadingTickets, setLoadingTickets] = useState(isStaff)
+
+  useEffect(() => {
+    if (!isStaff) return
+
+    getMyStatistics()
+      .then(setStats)
+      .catch(() => {})
+      .finally(() => setLoadingStats(false))
+
+    getMyRecentTickets()
+      .then(setRecentTickets)
+      .catch(() => {})
+      .finally(() => setLoadingTickets(false))
+  }, [isStaff])
+
+  // Quick action cards
   const clientCards = [
-    { icon: Ticket, label: 'Moji tiketi', description: 'Pregledajte i pratite vaše tikete za podršku', to: '/mytickets', color: 'bg-navy-600' },
+    { icon: Ticket, label: 'Moji tiketi', description: 'Pregledajte i pratite vaše tikete', to: '/mytickets', color: 'bg-navy-600' },
     { icon: PlusCircle, label: 'Kreiraj tiket', description: 'Podnesite novi zahtjev za podršku', to: '/create-ticket', color: 'bg-emerald-500' },
   ]
 
-  const staffCards = [
-    { 
-      icon: Ticket, 
-      label: user?.role === 'TECHNICIAN' ? 'Dodijeljeni meni' : 'Svi tiketi', 
-      description: user?.role === 'TECHNICIAN' ? 'Pregledajte vaše dodijeljene tikete' : 'Pregledajte i upravljajte tiketima za podršku', 
-      to: user?.role === 'TECHNICIAN' ? '/assigned' : '/tickets', 
-      color: 'bg-navy-600' 
-    },
+  const agentCards = [
+    { icon: Ticket, label: 'Svi tiketi', description: 'Pregledajte i upravljajte svim tiketima', to: '/tickets', color: 'bg-navy-600' },
+    { icon: Ticket, label: 'Dodijeljeni meni', description: 'Tiketi dodijeljeni vama', to: '/assigned', color: 'bg-blue-500' },
+    { icon: BarChart2, label: 'Moja statistika', description: 'Detaljan pregled vaših performansi', to: '/statistics', color: 'bg-violet-500' },
   ]
 
-  const cards = user?.role === 'CLIENT' ? clientCards : staffCards
+  const techCards = [
+    { icon: Ticket, label: 'Dodijeljeni meni', description: 'Tiketi dodijeljeni vama', to: '/assigned', color: 'bg-navy-600' },
+    { icon: BarChart2, label: 'Moja statistika', description: 'Detaljan pregled vaših performansi', to: '/statistics', color: 'bg-violet-500' },
+  ]
+
+  const adminCards = [
+    { icon: Ticket, label: 'Svi tiketi', description: 'Pregledajte i upravljajte tiketima', to: '/tickets', color: 'bg-navy-600' },
+    { icon: LayoutDashboard, label: 'FAQ', description: 'Upravljajte često postavljanim pitanjima', to: '/faq', color: 'bg-emerald-500' },
+  ]
+
+  const cards = {
+    CLIENT: clientCards,
+    AGENT: agentCards,
+    TECHNICIAN: techCards,
+    ADMINISTRATOR: adminCards,
+  }[user?.role] ?? []
+
+  // Condensed stats config
+  const miniStats = stats ? [
+    { icon: Ticket,        label: 'Otvoreni',         value: stats.openTicketsCount,                    color: 'bg-blue-500' },
+    { icon: CheckCircle,   label: 'Zatvoreni',         value: stats.closedTicketsCount,                  color: 'bg-emerald-500' },
+    { icon: AlertCircle,   label: 'Čeka zatvaranje',   value: stats.pendingClosureCount,                 color: 'bg-amber-500' },
+    { icon: MessageSquare, label: 'Prosj. 1. odgovor', value: formatMinutes(stats.avgFirstResponseMinutes), color: 'bg-violet-500' },
+    { icon: Clock,         label: 'Prosj. rješavanje', value: formatHours(stats.avgResolutionHours),     color: 'bg-navy-600' },
+    ...(user?.role === 'AGENT'
+      ? [{ icon: Star, label: 'Prosj. ocjena', value: formatRating(stats.avgRating), color: 'bg-yellow-500' }]
+      : []),
+  ] : []
 
   const roleDescription = {
     CLIENT: 'Ovdje je pregled vašeg korisničkog računa za podršku.',
@@ -54,25 +195,62 @@ export default function Dashboard() {
     <div className="space-y-6">
       {/* Welcome banner */}
       <div className="bg-gradient-to-r from-navy-800 to-navy-700 rounded-xl p-6 text-white">
-        <h2 className="text-xl font-bold">
-          Dobrodošli nazad, {user?.firstName}!
-        </h2>
+        <h2 className="text-xl font-bold">Dobrodošli nazad, {user?.firstName}!</h2>
         <p className="text-navy-200 text-sm mt-1">
-          {roleDescription[user?.role] || 'Dobrodošli u TelecomSupport.'}
+          {roleDescription[user?.role] ?? 'Dobrodošli u TelecomSupport.'}
         </p>
       </div>
 
-      {/* Quick action cards */}
+      {/* Quick actions */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-          Brze akcije
-        </h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Brze akcije</h3>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3">
           {cards.map((card) => (
             <QuickCard key={card.to} {...card} />
           ))}
         </div>
       </div>
+
+      {/* Stats + Recent tickets — samo za AGENT i TECHNICIAN */}
+      {isStaff && (
+        <>
+          {/* Condensed stats */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Moja statistika</h3>
+            {loadingStats ? (
+              <div className="flex items-center gap-2 text-gray-400 text-sm py-2">
+                <Loader2 size={16} className="animate-spin" /> Učitavanje...
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+                {miniStats.map((s) => (
+                  <MiniStat key={s.label} {...s} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Recently updated tickets */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Nedavna aktivnost</h3>
+            {loadingTickets ? (
+              <div className="flex items-center gap-2 text-gray-400 text-sm py-2">
+                <Loader2 size={16} className="animate-spin" /> Učitavanje...
+              </div>
+            ) : recentTickets.length === 0 ? (
+              <div className="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-6 text-center text-sm text-gray-400">
+                Nema dodijeljenih tiketa.
+              </div>
+            ) : (
+              <div className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+                {recentTickets.map((t) => (
+                  <RecentTicketRow key={t.ticketId} ticket={t} />
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/Project/frontend/src/pages/Notifications.jsx
+++ b/Project/frontend/src/pages/Notifications.jsx
@@ -1,0 +1,97 @@
+import { useNotifications } from '../context/NotificationContext'
+import { Bell, CheckCheck } from 'lucide-react'
+
+function timeAgo(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'upravo'
+  if (m < 60) return `prije ${m} min`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `prije ${h}h`
+  const d = Math.floor(h / 24)
+  return `prije ${d}d`
+}
+
+const typeLabel = {
+  TICKET_ASSIGNED: 'Dodijeljen tiket',
+  TICKET_FORWARDED: 'Proslijeđen tiket',
+  TICKET_RESPONSE: 'Odgovor na tiket',
+  STATUS_CHANGED: 'Promjena statusa',
+  TICKET_CLOSED: 'Tiket zatvoren',
+}
+
+const typeColor = {
+  TICKET_ASSIGNED: 'bg-blue-100 text-blue-700',
+  TICKET_FORWARDED: 'bg-violet-100 text-violet-700',
+  TICKET_RESPONSE: 'bg-emerald-100 text-emerald-700',
+  STATUS_CHANGED: 'bg-amber-100 text-amber-700',
+  TICKET_CLOSED: 'bg-gray-100 text-gray-600',
+}
+
+export default function Notifications() {
+  const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications()
+
+  return (
+    <div className="space-y-6">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">Notifikacije</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {unreadCount > 0 ? `${unreadCount} nepročitanih` : 'Sve notifikacije su pročitane'}
+          </p>
+        </div>
+        {unreadCount > 0 && (
+          <button
+            onClick={markAllAsRead}
+            className="flex items-center gap-2 px-4 py-2 bg-navy-600 text-white text-sm font-medium rounded-lg hover:bg-navy-700 transition-colors"
+          >
+            <CheckCheck size={16} />
+            Označi sve kao pročitano
+          </button>
+        )}
+      </div>
+
+      {/* List */}
+      {notifications.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-100 shadow-sm px-4 py-12 text-center">
+          <Bell size={32} className="mx-auto text-gray-300 mb-3" />
+          <p className="text-sm text-gray-400">Nemate notifikacija.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+          {notifications.map((n) => (
+            <div
+              key={n.notificationId}
+              onClick={() => { if (!n.isRead) markAsRead(n.notificationId) }}
+              className={`flex items-start gap-4 px-5 py-4 border-b border-gray-50 last:border-0 transition-colors ${
+                !n.isRead ? 'bg-blue-50/50 cursor-pointer hover:bg-blue-50' : 'cursor-default'
+              }`}
+            >
+              {/* Unread dot */}
+              <div className="pt-1.5 flex-shrink-0">
+                {!n.isRead ? (
+                  <span className="block w-2.5 h-2.5 rounded-full bg-blue-500" />
+                ) : (
+                  <span className="block w-2.5 h-2.5 rounded-full bg-transparent" />
+                )}
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="text-sm font-semibold text-gray-900">{n.title}</p>
+                  <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${typeColor[n.notificationType] ?? 'bg-gray-100 text-gray-600'}`}>
+                    {typeLabel[n.notificationType] ?? n.notificationType}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 mt-0.5">{n.content}</p>
+                <p className="text-xs text-gray-400 mt-1">{timeAgo(n.sentDate)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/Project/frontend/src/pages/Notifications.jsx
+++ b/Project/frontend/src/pages/Notifications.jsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
 import { useNotifications } from '../context/NotificationContext'
 import { Bell, CheckCheck } from 'lucide-react'
 
@@ -29,7 +31,17 @@ const typeColor = {
 }
 
 export default function Notifications() {
+  const navigate = useNavigate()
+  const { user } = useAuth()
   const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications()
+
+  function handleClick(n) {
+    if (!n.isRead) markAsRead(n.notificationId)
+    if (n.ticketId) {
+      const path = user?.role === 'CLIENT' ? `/mytickets/${n.ticketId}` : `/tickets/${n.ticketId}`
+      navigate(path)
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -63,10 +75,9 @@ export default function Notifications() {
           {notifications.map((n) => (
             <div
               key={n.notificationId}
-              // TODO: dodati ticketId u Notification entitet i DTO kako bi klik redirectao na odgovarajući tiket
-          onClick={() => { if (!n.isRead) markAsRead(n.notificationId) }}
-              className={`flex items-start gap-4 px-5 py-4 border-b border-gray-50 last:border-0 transition-colors ${
-                !n.isRead ? 'bg-blue-50/50 cursor-pointer hover:bg-blue-50' : 'cursor-default'
+              onClick={() => handleClick(n)}
+              className={`flex items-start gap-4 px-5 py-4 border-b border-gray-50 last:border-0 transition-colors cursor-pointer hover:bg-gray-50 ${
+                !n.isRead ? 'bg-blue-50/50 hover:bg-blue-50' : ''
               }`}
             >
               {/* Unread dot */}

--- a/Project/frontend/src/pages/Notifications.jsx
+++ b/Project/frontend/src/pages/Notifications.jsx
@@ -63,7 +63,8 @@ export default function Notifications() {
           {notifications.map((n) => (
             <div
               key={n.notificationId}
-              onClick={() => { if (!n.isRead) markAsRead(n.notificationId) }}
+              // TODO: dodati ticketId u Notification entitet i DTO kako bi klik redirectao na odgovarajući tiket
+          onClick={() => { if (!n.isRead) markAsRead(n.notificationId) }}
               className={`flex items-start gap-4 px-5 py-4 border-b border-gray-50 last:border-0 transition-colors ${
                 !n.isRead ? 'bg-blue-50/50 cursor-pointer hover:bg-blue-50' : 'cursor-default'
               }`}

--- a/Project/frontend/src/pages/Statistics.jsx
+++ b/Project/frontend/src/pages/Statistics.jsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { getMyStatistics } from '../services/userService'
+import {
+  Ticket,
+  CheckCircle,
+  Clock,
+  MessageSquare,
+  Star,
+  AlertCircle,
+  Loader2,
+} from 'lucide-react'
+
+function StatCard({ icon: Icon, label, value, color, description }) {
+  return (
+    <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-sm text-gray-500 mb-1">{label}</p>
+          <p className="text-2xl font-bold text-gray-900">
+            {value ?? <span className="text-gray-400 text-lg">—</span>}
+          </p>
+          {description && (
+            <p className="text-xs text-gray-400 mt-1">{description}</p>
+          )}
+        </div>
+        <div className={`w-11 h-11 rounded-xl flex items-center justify-center ${color}`}>
+          <Icon size={20} className="text-white" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatMinutes(minutes) {
+  if (minutes == null) return null
+  if (minutes < 60) return `${Math.round(minutes)} min`
+  const h = Math.floor(minutes / 60)
+  const m = Math.round(minutes % 60)
+  return m > 0 ? `${h}h ${m}min` : `${h}h`
+}
+
+function formatHours(hours) {
+  if (hours == null) return null
+  if (hours < 1) return `${Math.round(hours * 60)} min`
+  if (hours < 24) return `${hours.toFixed(1)}h`
+  const days = Math.floor(hours / 24)
+  const h = Math.round(hours % 24)
+  return h > 0 ? `${days}d ${h}h` : `${days}d`
+}
+
+function formatRating(rating) {
+  if (rating == null) return null
+  return `${rating.toFixed(1)} / 5`
+}
+
+export default function Statistics() {
+  const { user } = useAuth()
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getMyStatistics()
+      .then((data) => { setStats(data); setError(null) })
+      .catch(() => setError('Greška pri učitavanju statistike.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48 text-gray-400">
+        <Loader2 size={24} className="animate-spin mr-2" />
+        <span className="text-sm">Učitavanje statistike...</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-red-500 bg-red-50 border border-red-100 rounded-xl p-4">
+        <AlertCircle size={18} />
+        <span className="text-sm">{error}</span>
+      </div>
+    )
+  }
+
+  const cards = [
+    {
+      icon: Ticket,
+      label: 'Otvoreni tiketi',
+      value: stats.openTicketsCount,
+      color: 'bg-blue-500',
+      description: 'Trenutno aktivni tiketi',
+    },
+    {
+      icon: CheckCircle,
+      label: 'Zatvoreni tiketi',
+      value: stats.closedTicketsCount,
+      color: 'bg-emerald-500',
+      description: 'Uspješno riješeni tiketi',
+    },
+    {
+      icon: AlertCircle,
+      label: 'Čeka zatvaranje',
+      value: stats.pendingClosureCount,
+      color: 'bg-amber-500',
+      description: 'Tiketi na čekanju potvrde',
+    },
+    {
+      icon: MessageSquare,
+      label: 'Prosj. prvi odgovor',
+      value: formatMinutes(stats.avgFirstResponseMinutes),
+      color: 'bg-violet-500',
+      description: 'Prosječno vrijeme do prvog odgovora',
+    },
+    {
+      icon: Clock,
+      label: 'Prosj. rješavanje',
+      value: formatHours(stats.avgResolutionHours),
+      color: 'bg-navy-600',
+      description: 'Prosječno vrijeme od otvaranja do zatvaranja',
+    },
+  ]
+
+  if (user?.role === 'AGENT') {
+    cards.push({
+      icon: Star,
+      label: 'Prosječna ocjena',
+      value: formatRating(stats.avgRating),
+      color: 'bg-yellow-500',
+      description: 'Ocjena korisnika na zatvorenim tiketima',
+    })
+  }
+
+  const totalTickets = stats.openTicketsCount + stats.closedTicketsCount + stats.pendingClosureCount
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-navy-800 to-navy-700 rounded-xl p-6 text-white">
+        <h2 className="text-xl font-bold">Moja statistika</h2>
+        <p className="text-navy-200 text-sm mt-1">
+          Pregled vašeg rada i performansi unutar sistema
+        </p>
+      </div>
+
+      {/* Ukupno tiketa — summary */}
+      {totalTickets === 0 ? (
+        <div className="bg-white rounded-xl p-8 shadow-sm border border-gray-100 text-center">
+          <Ticket size={36} className="mx-auto text-gray-300 mb-3" />
+          <p className="text-gray-500 text-sm">Nema dodijeljenih tiketa za prikaz statistike.</p>
+        </div>
+      ) : (
+        <>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+              Opterećenje
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              {cards.slice(0, 3).map((card) => (
+                <StatCard key={card.label} {...card} />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+              Performanse
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {cards.slice(3).map((card) => (
+                <StatCard key={card.label} {...card} />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/Project/frontend/src/pages/Statistics.jsx
+++ b/Project/frontend/src/pages/Statistics.jsx
@@ -11,7 +11,8 @@ import {
   Loader2,
 } from 'lucide-react'
 
-function StatCard({ icon: Icon, label, value, color, description }) {
+function StatCard({ icon, label, value, color, description }) {
+  const Icon = icon
   return (
     <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100">
       <div className="flex items-start justify-between">

--- a/Project/frontend/src/pages/TicketDetail.jsx
+++ b/Project/frontend/src/pages/TicketDetail.jsx
@@ -607,6 +607,18 @@ export default function TicketDetail() {
                         </p>
                     ) : (
                         allComments.map((comment) => {
+                            if (comment.isSystemMessage) {
+                                return (
+                                    <div key={comment.commentId} className="flex items-center gap-3 py-1">
+                                        <div className="flex-1 border-t border-gray-100" />
+                                        <span className="text-xs text-gray-400 bg-gray-50 px-3 py-1 rounded-full border border-gray-100 whitespace-nowrap">
+                                            {comment.content}
+                                        </span>
+                                        <div className="flex-1 border-t border-gray-100" />
+                                    </div>
+                                )
+                            }
+
                             const initials = comment.authorName
                                 .split(' ')
                                 .map((p) => p[0])

--- a/Project/frontend/src/services/notificationService.js
+++ b/Project/frontend/src/services/notificationService.js
@@ -1,0 +1,26 @@
+import * as signalR from '@microsoft/signalr'
+import api from './api'
+
+export async function getNotifications() {
+  const response = await api.get('/notifications')
+  return response.data
+}
+
+export async function markAsRead(notificationId) {
+  await api.post(`/notifications/${notificationId}/read`)
+}
+
+export async function markAllAsRead() {
+  await api.post('/notifications/read-all')
+}
+
+export function createNotificationConnection() {
+  const token = sessionStorage.getItem('accessToken') ?? ''
+  return new signalR.HubConnectionBuilder()
+    .withUrl('/notificationhub', {
+      accessTokenFactory: () => token,
+    })
+    .withAutomaticReconnect()
+    .configureLogging(signalR.LogLevel.Warning)
+    .build()
+}

--- a/Project/frontend/src/services/userService.js
+++ b/Project/frontend/src/services/userService.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+// PB-42: Dohvati statistiku rada za prijavljenog agenta ili tehničara
+export async function getMyStatistics() {
+  const response = await api.get('/users/me/statistics')
+  return response.data
+}
+
+// Dashboard: Dohvati 5 najrecentnijih tiketa za agenta ili tehničara
+export async function getMyRecentTickets() {
+  const response = await api.get('/users/me/recent-tickets')
+  return response.data
+}

--- a/Project/frontend/src/test/Dashboard.test.jsx
+++ b/Project/frontend/src/test/Dashboard.test.jsx
@@ -31,14 +31,14 @@ describe('Dashboard', () => {
   it('shows CLIENT cards (Moji tiketi + Kreiraj tiket) for CLIENT role', () => {
     mocks.user = { firstName: 'Emir', role: 'CLIENT' }
     render(<Dashboard />)
-    expect(screen.getByText('Moji tiketi')).toBeInTheDocument()
-    expect(screen.getByText('Kreiraj tiket')).toBeInTheDocument()
+    expect(screen.getAllByText('Moji tiketi')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Kreiraj tiket')[0]).toBeInTheDocument()
   })
 
   it('does not show Kreiraj tiket for AGENT role', () => {
     mocks.user = { firstName: 'Haris', role: 'AGENT' }
     render(<Dashboard />)
-    expect(screen.getByText('Svi tiketi')).toBeInTheDocument()
+    expect(screen.getAllByText('Svi tiketi')[0]).toBeInTheDocument()
     expect(screen.queryByText('Kreiraj tiket')).not.toBeInTheDocument()
   })
 

--- a/Project/frontend/vite.config.js
+++ b/Project/frontend/vite.config.js
@@ -23,6 +23,11 @@ export default defineConfig({
         ws: true,
         secure: false,
       },
+      '/notificationhub': {
+        target: 'http://localhost:5122',
+        ws: true,
+        secure: false,
+      },
     },
   },
   esbuild: { jsx: 'automatic' },

--- a/Sprint8/AIUsageLog.md
+++ b/Sprint8/AIUsageLog.md
@@ -1,0 +1,72 @@
+# AI Usage Log – Sprint 8
+
+AI Usage Log je obavezan u AI-enabled fazi projekta.
+
+Za svaki relevantan slucaj koristenja AI potrebno je evidentirati:
+- Datum
+- Sprint broj
+- Alat koji je koristen
+- Svrha koristenja
+- Kratak opis zadatka ili upita
+- Sta je AI predlozio ili generisao
+- Sta je tim prihvatio
+- Sta je tim izmijenio
+- Sta je tim odbacio
+- Rizici, problemi ili greske koje su uocene
+- Ko je koristio alat
+
+AI Usage Log ne sluzi za kaznjavanje koristenja AI, nego za transparentnost i procjenu zrelosti u koristenju alata.
+
+---
+
+## Unos #1
+
+| Polje | Detalji |
+|---|---|
+| Datum | 16.05.2026 |
+| Sprint broj | Sprint 8 |
+| Alat koji je koristen | Claude Code (claude-sonnet-4-6) |
+| Svrha koristenja | Implementacija PB-42: Statistika agenta i tehničara |
+| Kratak opis zadatka ili upita | Implementirati prikaz lične statistike rada za agente i tehničare: backend endpoint koji izračunava i vraća broj otvorenih/zatvorenih tiketa, tiketa na čekanju zatvaranja, prosječno vrijeme prvog odgovora, prosječno vrijeme rješavanja i prosječnu ocjenu (samo agenti). Frontend prikaz na zasebnoj stranici i kondenzovani prikaz na Dashboardu. |
+| Sta je AI predlozio ili generisao | Backend: `GetMyStatistics` metodu u `UserService`-u sa LINQ upitima za sve metrike, `AgentStatisticsDto`, proširenje `IUserService` i `UserController`. Frontend: `Statistics.jsx` stranicu sa `StatCard` komponentama, proširenje `Dashboard.jsx` sa `MiniStat` komponentama i blokom nedavnih tiketa (`RecentTicketRow`), te `getMyStatistics` i `getMyRecentTickets` u `userService.js`. ESLint ispravka: promjena `{ icon: Icon }` destrukturiranja u `{ icon }` + `const Icon = icon` u `StatCard`, `QuickCard` i `MiniStat` komponentama zbog CI ESLint pravila `no-unused-vars`. |
+| Sta je tim prihvatio | Cjelokupnu backend implementaciju (servis, DTO, controller), strukturu `Statistics.jsx` stranice i Dashboard proširenja, te pristup formaterima (`formatMinutes`, `formatHours`, `formatRating`). |
+| Sta je tim izmijenio | Vizualni dizajn StatCard komponenti prilagođen Tailwind klasama projekta; rute i navigacija usklađene s postojećom strukturom App.jsx. |
+| Sta je tim odbacio | Ništa strukturalno — predložena implementacija je prihvaćena u cjelini nakon provjere. |
+| Rizici, problemi ili greske koje su uocene | ESLint CI pravilo `no-unused-vars` nije prepoznavalo JSX alias destrukturiranje `{ icon: Icon }` kao korištenu varijablu. Greška je otkrivena tek pri CI pokretanju — lokalni ESLint nije javljao problem. Dashboard.test.jsx padao na `getByText` jer `QuickCard` renderuje label dva puta (mobilni + desktop layout); ispravno rješenje je `getAllByText(...)[0]`. |
+| Ko je koristio alat | Uma Mahmutović |
+
+---
+
+## Unos #2
+
+| Polje | Detalji |
+|---|---|
+| Datum | 16.05.2026 |
+| Sprint broj | Sprint 8 |
+| Alat koji je koristen | Claude Code (claude-sonnet-4-6) |
+| Svrha koristenja | Implementacija PB-49: Notifikacije (kompletna implementacija) |
+| Kratak opis zadatka ili upita | Implementirati kompletan notifikacijski sistem: backend generisanje notifikacija za sve predviđene događaje na tiketima (dodjela, prosljeđivanje, odgovor, zatvaranje, promjena statusa), real-time isporuka putem SignalR, API endpointi za upravljanje notifikacijama, te frontend prikaz (bell ikona, dropdown, zasebna stranica, redirect na tiket pri kliku). |
+| Sta je AI predlozio ili generisao | Backend: `NotificationHub` (SignalR hub sa `JoinUserGroup`), `INotificationPusher` interfejs i `NotificationPusher` implementaciju (apstrakcija da BLL ne ovisi o `IHubContext`), proširenje `NotificationService` poslovnom logikom (`SendNotificationAsync`), `NotificationRepository` s `ExecuteUpdateAsync` za bulk mark-as-read, `NotificationController` s tri endpointa (`GET`, `POST /{id}/read`, `POST /read-all`), JWT konfiguraciju za čitanje `access_token` query parametra (potrebno za SignalR WebSocket handshake), dodavanje `int? TicketId` na `Notification` entitet s EF migracijom, te injektovanje `INotificationService` u `TicketService` i `CommentService` s notifikacionim pozivima po svim predviđenim događajima. Frontend: `notificationService.js` s `createNotificationConnection()` (SignalR konekcija s `accessTokenFactory`), `NotificationContext.jsx` (upravljanje stanjem, real-time push, `markAsRead`, `markAllAsRead`, `reload`), bell ikonu u `Header.jsx` s crvenim badge-om i dropdownom, `Notifications.jsx` stranicu, link u `Sidebar.jsx` s unread badge-om, role-based redirect na tiket pri kliku. Vite proxy ispravku: dodavanje `/notificationhub` s `ws: true` u `vite.config.js`. |
+| Sta je tim prihvatio | Cjelokupnu arhitekturu (INotificationPusher apstrakcija, NotificationHub, NotificationContext sa SignalR), sva notifikaciona okidanja po događajima, frontend komponente, role-based redirect logiku, te Vite proxy ispravku. |
+| Sta je tim izmijenio | Vizualni stil dropdown komponente i stranice notifikacija prilagođen Tailwind klasama projekta. Pravilo o klijentu koji dobiva TICKET_FORWARDED notifikaciju dodano je naknadno (nije bilo u inicijalnoj specifikaciji). |
+| Sta je tim odbacio | Prijedlog za polling kao fallback mehanizam — SignalR s `withAutomaticReconnect()` je dovoljan. |
+| Rizici, problemi ili greske koje su uocene | ESLint pravilo `react-hooks/set-state-in-effect`: linter prati pozive funkcija kroz call graph — poziv `load()` unutar efekta triggerovao je grešku jer `load` interno poziva `setNotifications`. Riješeno inline `getNotifications().then(...)` direktno u efektu. SignalR WebSocket nije radio lokalno zbog nedostajuće Vite proxy konfiguracije — notifikacije su stizale samo pri osvježavanju stranice. Ispravka: dodati proxy entry za `/notificationhub` s `ws: true`. |
+| Ko je koristio alat | Uma Mahmutović |
+
+---
+
+## Unos #3
+
+| Polje | Detalji |
+|---|---|
+| Datum | 16.05.2026 |
+| Sprint broj | Sprint 8 |
+| Alat koji je koristen | Claude Code (claude-sonnet-4-6) |
+| Svrha koristenja | Implementacija SB-08: Sistemske poruke u chatu tiketa pri prosljeđivanju |
+| Kratak opis zadatka ili upita | Kada agent proslijedi tiket drugom agentu ili tehničaru, automatski dodati sistemsku poruku u chat tiketa koja vidljivo obavještava sve učesnike o prosljeđivanju (npr. "Tiket je proslijeđen tehničaru: Ime Prezime"), uz real-time isporuku svim otvorenim instancama tiketa putem SignalR. |
+| Sta je AI predlozio ili generisao | Backend: dodavanje `bool IsSystemMessage` i nullable `int? AuthorId` na `Comment` entitet (sistemske poruke nemaju autora), EF migraciju `AddSystemCommentToComment`, `IChatPusher` interfejs u BLL i `ChatPusher` implementaciju u API (isti arhitekturni pattern kao `INotificationPusher` — razdvajanje BLL od `IHubContext`), `AddSystemCommentAsync` metodu u `ICommentService` i `CommentService` koja kreira komentar i broadcastuje ga putem `IChatPusher`, injektovanje `ICommentService` u `TicketService` i pozive `AddSystemCommentAsync` nakon svakog prosljeđivanja (agentu i tehničaru). Ažuriranje mapiranja u `CommentService` za nullable autora. Frontend: uvjetno renderovanje sistemskih poruka u `TicketDetail.jsx` kao centrirana pill linija s horizontalnim separatorima, bez avatara i bez oznake autora. Ažuriranje 20+ test fajlova: dodavanje `new Mock<ICommentService>().Object` kao 5. parametar `TicketService` konstruktoru i `new Mock<IChatPusher>().Object` kao 4. parametar `CommentService` konstruktoru. |
+| Sta je tim prihvatio | Arhitekturni pattern s `IChatPusher` apstrakcijom, implementaciju `AddSystemCommentAsync`, promjene na `Comment` entitetu i migraciju, frontend pill prikaz sistemskih poruka, sve ispravke testova. |
+| Sta je tim izmijenio | Vizualni stil pill komponente prilagođen konzistentnosti s ostatkom UI-a (boja, border, veličina fonta). |
+| Sta je tim odbacio | Prijedlog za zasebnu "Historija dodjela" sekciju na tiketu — ocijenjeno kao prekomplicirana opcija koja zahtijeva novi UI element i endpoint, dok sistemske poruke u chatu postižu isti cilj jednostavnijim putem. |
+| Rizici, problemi ili greske koje su uocene | Perl `sed` zamjena za ažuriranje test konstruktora bila je previše agresivna — slučajno je dodala `new Mock<ICommentService>().Object` i u `CommentService` konstruktor u `Sprint7UserStoriesSystemTests.cs` (koji prima samo 3 parametra). Otkriveno pri `dotnet build` i ručno ispravljeno. FK relacija `Comment.AuthorId → User.UserId` ostaje kao opcionalna veza u EF Core konfiguraciji bez izmjena u `AppDbContext.cs` jer EF Core automatski tretira nullable FK kao opcionalu relaciju. |
+| Ko je koristio alat | Uma Mahmutović |

--- a/Sprint8/DecisionLog.md
+++ b/Sprint8/DecisionLog.md
@@ -10,7 +10,7 @@ Decision Log treba pokazati da tim ne radi nasumično, nego svjesno donosi i pra
 
 | Polje | Detalji |
 |---|---|
-| **ID odluke** | ODL-S8-2 |
+| **ID odluke** | ODL-S8-1 |
 | **Datum** | 16.05.2026 |
 | **Kratak naziv odluke** | Redefinisanje PB-42 iz metrike izvještaja u statistiku agenta i tehničara |
 | **Opis problema ili pitanja** | PB-42 je originalno definisan kao "Prosječno vrijeme prvog odgovora" — agregirana metrika za admin izvještaje. Međutim, bez Admin Dashboarda (PB-45, planiranog za Sprint 11) ova metrika nema gdje biti prikazana, što je činilo PB-42 besmislenim u kontekstu Sprint 8. |
@@ -26,7 +26,7 @@ Decision Log treba pokazati da tim ne radi nasumično, nego svjesno donosi i pra
 
 | Polje | Detalji |
 |---|---|
-| **ID odluke** | ODL-S8-3 |
+| **ID odluke** | ODL-S8-2 |
 | **Datum** | 16.05.2026 |
 | **Kratak naziv odluke** | Dodavanje PB-49 Notifikacije kao nove backlog stavke |
 | **Opis problema ili pitanja** | Notifikacije nisu bile eksplicitno definisane kao Product Backlog stavka, iako je infrastruktura (entitet `Notification`, `NotificationType` enum, repozitorij, servis i kontroler kao skeleton) bila pripremljena u Sprint 7. Bez formalne PB stavke, implementacija nije mogla biti planirana ni praćena. |
@@ -42,7 +42,7 @@ Decision Log treba pokazati da tim ne radi nasumično, nego svjesno donosi i pra
 
 | Polje | Detalji |
 |---|---|
-| **ID odluke** | ODL-S8-4 |
+| **ID odluke** | ODL-S8-3 |
 | **Datum** | 16.05.2026 |
 | **Kratak naziv odluke** | Dodavanje PB-50 kao zasebne stavke za metriku prvog odgovora u admin izvještajima |
 | **Opis problema ili pitanja** | Redefinisanjem PB-42, originalna funkcionalnost "Prosječno vrijeme prvog odgovora" kao admin metrika nije izgubljena, ali nije bila smještena ni u jednu PB stavku. Potrebno ju je formalno evidentirati za Sprint 11. |
@@ -50,6 +50,39 @@ Decision Log treba pokazati da tim ne radi nasumično, nego svjesno donosi i pra
 | **Odabrana opcija** | 2. Dodati PB-50 kao eksplicitnu stavku za ovu metriku u Sprint 11. |
 | **Razlog izbora** | Admin Dashboard (PB-45) je već složena stavka (L). Odvajanje metrike prvog odgovora u zasebnu stavku osigurava bolji granularitet planiranja, jasniji scope i lakše testiranje u okviru Sprint 11. Podaci za izračun već postoje u bazi (`Comment.DateTime` i `Ticket.CreatedDate`) pa nema potrebe za dodatnom migracijom. |
 | **Posljedice odluke** | PB-50 "Prosječno vrijeme prvog odgovora — izvještaj za admina" dodana je u Product Backlog sa prioritetom 2 i složenošću S za Sprint 11. |
+| **Status odluke** | aktivna |
+
+---
+
+
+## Odluka #4
+
+| Polje | Detalji |
+|---|---|
+| **ID odluke** | ODL-S8-4 |
+| **Datum** | 16.05.2026 |
+| **Kratak naziv odluke** | Klijent dobija `TICKET_FORWARDED` notifikaciju pri prosljeđivanju tiketa |
+| **Opis problema ili pitanja** | Originalna implementacija je slala `TICKET_FORWARDED` notifikaciju samo novom agentu ili tehničaru. Klijent nije bio informisan da je odgovorna osoba za njegov tiket promijenjena. |
+| **Razmatrane opcije** | 1. Samo novi agent/tehničar dobija notifikaciju (originalno). <br> 2. I novi agent/tehničar i klijent (kreator tiketa) dobijaju notifikaciju. |
+| **Odabrana opcija** | 2. I klijent dobija `TICKET_FORWARDED` notifikaciju. |
+| **Razlog izbora** | Klijent mora biti informisan o promjeni odgovorne osobe bez potrebe za osvježavanjem stranice. Ovo je osnovna zahtijevana transparentnost helpdesk sistema. |
+| **Posljedice odluke** | U `TicketService.ExecuteForwardAsync` i `ForwardTicketToTechnicianAsync` dodato je slanje notifikacije na `ticket.CreatorId` uz već postojeće slanje na novog agenta/tehničara. |
+| **Status odluke** | aktivna |
+
+---
+
+## Odluka #5
+
+| Polje | Detalji |
+|---|---|
+| **ID odluke** | ODL-S8-5 |
+| **Datum** | 16.05.2026 |
+| **Kratak naziv odluke** | Uvođenje sistemskih poruka u chatu tiketa pri prosljeđivanju |
+| **Opis problema ili pitanja** | Notifikacija informiše primatelja, ali ne ostavlja trajan trag u chatu tiketa. Klijent i ostali učesnici nemaju uvid u historiju prosljeđivanja direktno u razgovoru. |
+| **Razmatrane opcije** | 1. Samo notifikacija, bez zapisa u chatu. <br> 2. Notifikacija + automatska sistemska poruka u chatu ("Tiket je proslijeđen agentu: Ime Prezime"). <br> 3. Posebna sekcija "Historija dodjela" na tiketu. |
+| **Odabrana opcija** | 2. Notifikacija + sistemska poruka u chatu. |
+| **Razlog izbora** | Sistemska poruka u chatu ostavlja trajan, vidljiv zapis svim učesnicima. Implementaciono je najjednostavnija opcija jer koristi postojeću infrastrukturu komentara. Opcija 3 zahtijeva poseban UI element i API endpoint. |
+| **Posljedice odluke** | Dodat je `bool IsSystemMessage` i nullable `int? AuthorId` na `Comment` entitet. Kreirana EF migracija `AddSystemCommentToComment`. `CommentService` dobija `AddSystemCommentAsync` metodu i `IChatPusher` za real-time broadcast. Frontend prikazuje sistemske poruke kao centriranu pill liniju bez avatara. |
 | **Status odluke** | aktivna |
 
 ---

--- a/Sprint8/SprintBacklog.md
+++ b/Sprint8/SprintBacklog.md
@@ -14,13 +14,14 @@ Implementirati sistem notifikacija koji obavještava korisnike o događajima na 
 
 | ID | Naziv zadatka ili storyja | Povezani US | Odgovorna osoba ili osobe | Status | Napomena |
 |---|---|---|---|---|---|
-| SB-01 | PB-49 Notifikacije | US-58, US-59 | Uma | To-Do | Implementacija slanja i prikaza notifikacija za sve role |
+| SB-01 | PB-49 Notifikacije | US-58, US-59 | Uma | Done | Implementacija slanja i prikaza notifikacija za sve role, real-time via SignalR |
 | SB-02 | PB-36 Ažuriranje statusa tiketa | US-60 | Ajnur | To-Do | Tehničar mijenja status tiketa koji mu je dodijeljen |
 | SB-03 | PB-26 Ocjenjivanje tiketa | US-61 | Ajnur | To-Do | Korisnik ocjenjuje kvalitet rješenja nakon zatvaranja tiketa |
-| SB-04 | PB-42 Statistika agenta i tehničara | US-62, US-63 | Uma | To-Do | Prikaz lične statistike rada na profilnoj stranici |
+| SB-04 | PB-42 Statistika agenta i tehničara | US-62, US-63 | Uma | Done | Prikaz lične statistike rada na dashboardu |
 | SB-05 | PB-20 Upravljanje korisničkim profilom | US-64, US-65 | Merisa | To-Do | Korisnik mijenja email i lozinku svog profila |
 | SB-06 | PB-34 Pregled korisničkih profila (agent) | US-66, US-67 | Merisa | To-Do | Agent pregledava profile korisnika i historiju tiketa |
 | SB-07 | PB-21 Prikaz paketa i pretplata | US-68 | Eldar | To-Do | Korisnik vidi svoje aktivne pakete i pretplate |
+| SB-08 | Sistemske poruke u chatu pri prosljeđivanju tiketa | US-69 | Uma | Done | Proširenje PB-31: automatska poruka u chatu + real-time broadcast kada se tiket proslijedi |
 
 ---
 
@@ -36,10 +37,13 @@ Implementirati sistem notifikacija koji obavještava korisnike o događajima na 
 **Acceptance Criteria:**
 - Kada je tiket dodijeljen agentu ili tehničaru, sistem mora automatski kreirati notifikaciju tipa `TICKET_ASSIGNED` za tog korisnika
 - Kada je tiket proslijeđen drugom agentu ili tehničaru, sistem mora kreirati notifikaciju tipa `TICKET_FORWARDED` za novog vlasnika tiketa
+- Kada je tiket proslijeđen, sistem mora kreirati notifikaciju tipa `TICKET_FORWARDED` i za kreatora tiketa (klijenta), kako bi bio obaviješten o promjeni odgovorne osobe
 - Kada agent ili tehničar pošalje poruku na tiketu, sistem mora kreirati notifikaciju tipa `TICKET_RESPONSE` za kreatora tiketa
 - Kada korisnik pošalje poruku na tiketu, sistem mora kreirati notifikaciju tipa `TICKET_RESPONSE` za trenutnog vlasnika tiketa
 - Kada se tiket zatvori, sistem mora kreirati notifikaciju tipa `TICKET_CLOSED` za kreatora tiketa
 - Kada tehničar promijeni status tiketa, sistem mora kreirati notifikaciju tipa `STATUS_CHANGED` za kreatora tiketa
+- Notifikacije moraju biti isporučene u realnom vremenu putem SignalR konekcije, bez potrebe za osvježavanjem stranice
+- Svaka notifikacija mora sadržavati referencu na odgovarajući tiket (`TicketId`) kako bi redirect bio moguć
 - Sistem ne smije kreirati notifikaciju za korisnika koji je sam izvršio tu akciju
 
 ---
@@ -48,10 +52,12 @@ Implementirati sistem notifikacija koji obavještava korisnike o događajima na 
 *Kao korisnik, agent ili tehničar, želim da upravljam svojim notifikacijama i označim ih kao pročitane, kako bih imao jasan pregled nepročitanih obavještenja.*
 
 **Acceptance Criteria:**
-- Kada je korisnik prijavljen u sistem, sistem mora prikazivati broj nepročitanih notifikacija u vidu badge-a
+- Kada je korisnik prijavljen u sistem, sistem mora prikazivati broj nepročitanih notifikacija u vidu badge-a u zaglavlju
 - Kada korisnik otvori pregled notifikacija, sistem mora prikazati sve notifikacije sortirane po datumu, od najnovijih
-- Kada korisnik klikne na notifikaciju, sistem mora označiti notifikaciju kao pročitanu i preusmjeriti ga na odgovarajući tiket
+- Kada korisnik klikne na notifikaciju, sistem mora označiti notifikaciju kao pročitanu i preusmjeriti ga na odgovarajući tiket (klijent na `/mytickets/:id`, agent/tehničar na `/tickets/:id`)
 - Sistem mora omogućiti označavanje svih notifikacija kao pročitane odjednom
+- Sistem mora prikazivati notifikacije u realnom vremenu — nova notifikacija se dodaje na vrh liste bez osvježavanja stranice
+- Sistem mora prikazivati link "Notifikacije" u bočnoj navigaciji s brojem nepročitanih
 - Sistem ne smije prikazivati notifikacije drugih korisnika
 - Kada korisnik nema notifikacija, sistem mora prikazati odgovarajuću poruku
 
@@ -188,6 +194,20 @@ Implementirati sistem notifikacija koji obavještava korisnike o događajima na 
 - Kada korisnik nema aktivnih paketa, sistem mora prikazati odgovarajuću poruku
 - Sistem ne smije prikazivati pakete i pretplate drugih korisnika
 - Agenti i tehničari ne smiju imati pristup ovoj sekciji za vlastiti nalog
+
+---
+
+## PB-31 (proširenje) — Sistemske poruke u chatu pri prosljeđivanju
+
+### US-69
+*Kao korisnik, želim da vidim u chatu tiketa poruku koja me obavještava kada je tiket proslijeđen drugoj osobi, kako bih imao jasan pregled toka rješavanja bez potrebe za zasebnom provjerom.*
+
+**Acceptance Criteria:**
+- Kada agent proslijedi tiket drugom agentu, sistem mora automatski dodati sistemsku poruku u chat tiketa u formatu: `"Tiket je proslijeđen agentu: Ime Prezime"`
+- Kada agent proslijedi tiket tehničaru, sistem mora automatski dodati sistemsku poruku u chat tiketa u formatu: `"Tiket je proslijeđen tehničaru: Ime Prezime"`
+- Sistemska poruka mora biti vidljiva svim učesnicima (klijent, agent, tehničar, admin) u realnom vremenu bez osvježavanja stranice
+- Sistemska poruka mora biti vizualno različita od regularnih poruka — prikazana kao centrirana pill linija, bez avatara i bez oznake autora
+- Sistemska poruka ne smije biti prikazana kao poruka korisnika niti smije imati polje za autora
 
 ---
 

--- a/Sprint8/SprintGoal.md
+++ b/Sprint8/SprintGoal.md
@@ -29,10 +29,11 @@ Dodatno, sprint uključuje proširenje profilnih stranica agenta i tehničara sa
 
 ## Očekivani deliverable-i
 
-- PB-49 Notifikacije — implementiran notifikacijski sistem za sve role
+- PB-49 Notifikacije — implementiran notifikacijski sistem za sve role s real-time SignalR isporukom
+- PB-42 Statistika agenta i tehničara — lična statistika na profilnoj stranici i dashboardu
+- SB-08 Sistemske poruke u chatu pri prosljeđivanju tiketa (proširenje PB-31)
 - PB-36 Ažuriranje statusa tiketa — tehničar mijenja status dodijeljenih tiketa
 - PB-26 Ocjenjivanje tiketa — korisnik ocjenjuje zatvoreni tiket (1–5, opcionalni komentar)
-- PB-42 Statistika agenta i tehničara — lična statistika na profilnoj stranici
 - PB-20 Upravljanje korisničkim profilom — promjena email adrese i lozinke
 - PB-34 Pregled korisničkih profila (agent) — agent vidi profil, historiju tiketa i pakete korisnika
 - PB-21 Prikaz paketa i pretplata — korisnik vidi svoje aktivne pakete i pretplate

--- a/Sprint8/UpdatedProductBacklog.md
+++ b/Sprint8/UpdatedProductBacklog.md
@@ -59,14 +59,14 @@ Ovaj dokument služi za praćenje i upravljanje zadacima u okviru razvoja proizv
 | [PB-39](#pb-39) | Izvještaj po statusu tiketa              | Feature        |     5     |     M     | Backlog     | Sprint 11   |
 | [PB-40](#pb-40) | Izvještaj po tipu problema               | Feature        |     3     |     S     | Backlog     | Sprint 11   |
 | [PB-41](#pb-41) | Prosječno vrijeme rješavanja tiketa      | Feature        |     1     |     M     | Backlog     | Sprint 11   |
-| [PB-42](#pb-42) | Statistika agenta i tehničara            | Feature        |     2     |     M     | To-Do       | Sprint 8    |
+| [PB-42](#pb-42) | Statistika agenta i tehničara            | Feature        |     2     |     M     | Done        | Sprint 8    |
 | [PB-43](#pb-43) | Izvještaj o opterećenju agenata          | Feature        |     2     |     M     | Backlog     | Sprint 11   |
 | [PB-44](#pb-44) | Izvještaj o ocjenama korisnika           | Feature        |     2     |     S     | Backlog     | Sprint 11   |
 | [PB-45](#pb-45) | Admin Dashboard sa ključnim metrikama    | Feature        |     1     |     L     | Backlog     | Sprint 11   |
 | [PB-46](#pb-46) | Export izvještaja                        | Feature        |     5     |     S     | Backlog     | Sprint 11   |
 | [PB-47](#pb-47) | FAQ segment                              | Feature        |     3     |     S     | Done        | Sprint 6    |
 | [PB-48](#pb-48) | Pregled historije dodijeljenih tiketa za agente | Feature | 1    |     M     | Done        | Sprint 7    |
-| [PB-49](#pb-49) | Notifikacije                             | Feature        |     1     |     L     | To-Do       | Sprint 8    |
+| [PB-49](#pb-49) | Notifikacije                             | Feature        |     1     |     L     | Done        | Sprint 8    |
 | [PB-50](#pb-50) | Prosječno vrijeme prvog odgovora (admin izvještaj) | Feature | 2  |     S     | Backlog     | Sprint 11   |
 
 ---
@@ -577,9 +577,9 @@ Ovaj dokument služi za praćenje i upravljanje zadacima u okviru razvoja proizv
 - **Tip Stavke:** Feature
 - **Prioritet:** 2
 - **Procjena složenosti ili napora:** M
-- **Status:** To-Do
+- **Status:** Done
 - **Veza sa sprintom ili release planom:** Sprint 8
-- **Napomena:** Redefinisano u Sprint 8 planiranju. Originalna metrika "Prosječno vrijeme prvog odgovora" za admin izvještaje evidentirana je kao PB-50.
+- **Napomena:** Redefinisano u Sprint 8 planiranju. Implementirano: backend `GET /api/user/my-statistics` endpoint, dedikirana stranica `/statistics`, te kondenzovani prikaz statistike i nedavnih tiketa na Dashboard-u za AGENT i TECHNICIAN role. Originalna metrika za admin izvještaje evidentirana je kao PB-50.
 
 ---
 
@@ -662,8 +662,9 @@ Ovaj dokument služi za praćenje i upravljanje zadacima u okviru razvoja proizv
 - **Tip Stavke:** Feature
 - **Prioritet:** 1
 - **Procjena složenosti ili napora:** L
-- **Status:** To-Do
+- **Status:** Done
 - **Veza sa sprintom ili release planom:** Sprint 8
+- **Napomena:** Implementirano: backend generisanje notifikacija za sve predviđene događaje (`TICKET_ASSIGNED`, `TICKET_FORWARDED`, `TICKET_RESPONSE`, `TICKET_CLOSED`, `STATUS_CHANGED`), real-time isporuka putem SignalR (`NotificationHub`), API endpointi za dohvat i označavanje pročitanog, frontend bell ikona s badge-om u headeru, dropdown s 5 najnovijih notifikacija, zasebna stranica `/notifications`, link u Sidebaru, klik na notifikaciju otvara odgovarajući tiket (role-based path), EF migracija `AddTicketIdToNotification`.
 
 ---
 


### PR DESCRIPTION
feat: implement notifications (PB-49), statistics (PB-42), system comments on forward (SB-08)

PB-49 Notifikacije:
- NotificationHub (SignalR), INotificationPusher abstraction (BLL/API separation),
  NotificationService business logic, NotificationController (GET, mark-as-read, mark-all-as-read)
- JWT configured to read access_token query param for SignalR WebSocket handshake
- Notifications triggered: TICKET_ASSIGNED (new agent/tech), TICKET_FORWARDED (new owner + client),
  TICKET_RESPONSE (comment), TICKET_CLOSED (creator), STATUS_CHANGED (creator)
- EF migration: AddTicketIdToNotification
- Frontend: NotificationContext (SignalR + state), bell icon with unread badge in Header,
  dropdown with 5 latest, Notifications page, Sidebar link, click redirects to ticket (role-based path)
- Vite proxy: added /notificationhub with ws:true for real-time in local dev
- Fixed ESLint: react-hooks/set-state-in-effect in NotificationContext,
  no-unused-vars (icon: Icon alias) in Dashboard/Statistics

PB-42 Statistika:
- Backend: GET /api/user/my-statistics endpoint, AgentStatisticsDto
- Frontend: Statistics.jsx page, Dashboard mini-stats + recent tickets for AGENT/TECHNICIAN
- Fixed Dashboard.test.jsx: getAllByText instead of getByText (label rendered twice in mobile+desktop layout)

SB-08 Sistemske poruke pri prosljeđivanju:
- Comment entity: IsSystemMessage bool + nullable AuthorId
- ICommentService.AddSystemCommentAsync + IChatPusher/ChatPusher (real-time broadcast to ticket group)
- TicketService: injects ICommentService, adds system comment + client TICKET_FORWARDED notification
  on both agent and technician forward
- EF migration: AddSystemCommentToComment
- Frontend: system comments rendered as centered pill line (no avatar, no author)
- Updated 20+ test constructors: +ICommentService mock (TicketService), +IChatPusher mock (CommentService)

Sprint8 docs: SprintBacklog, SprintGoal, UpdatedProductBacklog, DecisionLog, AIUsageLog