### PR TITLE
feat:pb 36: tehničar mijenja status tiketa

### DIFF
--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/TicketController.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/TicketController.cs
@@ -279,6 +279,30 @@ namespace TelecomSupportSystem.API.Controllers
             }
         }
 
+        // PB-36 / US-60: POST /api/tickets/{id}/status
+        // Tehničar mijenja status tiketa koji mu je dodijeljen
+        [HttpPost("{id:int}/status")]
+        public async Task<IActionResult> UpdateStatus(int id, [FromBody] UpdateTicketStatusDto dto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (userIdClaim is null || !int.TryParse(userIdClaim, out int userId) || role is null)
+                return Unauthorized();
+
+            try
+            {
+                await _ticketService.UpdateTicketStatusAsync(id, dto.Status, userId, role);
+                return Ok(new { message = "Status tiketa je uspješno ažuriran." });
+            }
+            catch (KeyNotFoundException) { return NotFound(); }
+            catch (UnauthorizedAccessException) { return Forbid(); }
+            catch (InvalidOperationException ex) { return BadRequest(new { poruka = ex.Message }); }
+        }
+
         // POST /api/tickets/{id}/close
         [HttpPost("{id:int}/close")]
         public async Task<IActionResult> CloseTicket(int id)

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Tickets/TicketDetailDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Tickets/TicketDetailDto.cs
@@ -20,5 +20,6 @@ namespace TelecomSupportSystem.BLL.DTOs.Tickets
 
         public string ClientName { get; set; } = string.Empty;
         public string AssignedAgentName { get; set; } = string.Empty;
+        public int? AssignedAgentId { get; set; }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Tickets/UpdateTicketStatusDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Tickets/UpdateTicketStatusDto.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using TelecomSupportSystem.DAL.Entities.Enums;
+
+namespace TelecomSupportSystem.BLL.DTOs.Tickets
+{
+    public class UpdateTicketStatusDto
+    {
+        [Required]
+        public TicketStatus Status { get; set; }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ITicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ITicketService.cs
@@ -39,6 +39,9 @@ namespace TelecomSupportSystem.BLL.Services.Interfaces
         // Internal Priority Management
         Task UpdateInternalPriorityAsync(int ticketId, InternalPriority priority, int userId, string role);
 
+        // PB-36 / US-60: Tehničar mijenja status tiketa koji mu je dodijeljen
+        Task UpdateTicketStatusAsync(int ticketId, TicketStatus newStatus, int userId, string role);
+
         // Closure Workflow
         Task CloseTicketAsync(int ticketId, int userId, string role);
         Task RequestClosureAsync(int ticketId, int userId, string role);

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
@@ -94,7 +94,63 @@ namespace TelecomSupportSystem.BLL.Services
                 AssignedAgentName = agentAssignment is not null
                     ? $"{agentAssignment.User.FirstName} {agentAssignment.User.LastName}"
                     : string.Empty,
+                AssignedAgentId = agentAssignment?.UserId,
             };
+        }
+
+        // PB-36 / US-60: Tehničar mijenja status tiketa koji mu je dodijeljen.
+        // Dozvoljeni ciljni statusi za tehničara: OPEN, CLOSURE_REQUESTED.
+        // Direktno zatvaranje (CLOSED) ide kroz client-confirm tok (request-closure / accept-closure),
+        // pa ovdje nije dozvoljeno da tehničar postavi CLOSED.
+        private static readonly TicketStatus[] TechnicianAllowedStatuses =
+            { TicketStatus.OPEN, TicketStatus.CLOSURE_REQUESTED };
+
+        public async Task UpdateTicketStatusAsync(int ticketId, TicketStatus newStatus, int userId, string role)
+        {
+            if (role != "TECHNICIAN")
+                throw new UnauthorizedAccessException("Samo tehničar može mijenjati status tiketa.");
+
+            if (!TechnicianAllowedStatuses.Contains(newStatus))
+                throw new InvalidOperationException("Odabrani status nije dozvoljen za tehničara.");
+
+            var ticket = await _ticketRepository.GetByIdWithDetailsAsync(ticketId)
+                ?? throw new KeyNotFoundException($"Tiket {ticketId} nije pronađen.");
+
+            if (ticket.Status == TicketStatus.CLOSED)
+                throw new InvalidOperationException("Status zatvorenog tiketa se ne može mijenjati.");
+
+            var latestAssignment = ticket.Assignments
+                .OrderByDescending(a => a.AssignmentDate)
+                .FirstOrDefault();
+
+            if (latestAssignment?.UserId != userId)
+                throw new UnauthorizedAccessException("Možete mijenjati status samo tiketa koji su vama dodijeljeni.");
+
+            if (ticket.Status == newStatus)
+                return;
+
+            var previousStatus = ticket.Status;
+            ticket.Status = newStatus;
+
+            if (newStatus == TicketStatus.CLOSURE_REQUESTED)
+            {
+                ticket.ClosureRequestedDate = DateTime.Now;
+                ticket.ClosureRequestedById = userId;
+                ticket.ClosureRequestStatus = ClosureRequestStatus.PENDING;
+            }
+            else if (newStatus == TicketStatus.OPEN && previousStatus == TicketStatus.CLOSURE_REQUESTED)
+            {
+                ticket.ClosureRequestStatus = ClosureRequestStatus.REJECTED;
+            }
+
+            await _ticketRepository.UpdateAsync(ticket);
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Promjena statusa tiketa",
+                $"Status vašeg tiketa \"{ticket.Title}\" je promijenjen na '{newStatus}'.",
+                NotificationType.STATUS_CHANGED,
+                ticket.TicketId);
         }
 
         public async Task UpdateInternalPriorityAsync(int ticketId, InternalPriority priority, int userId, string role)

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketStatusUpdateTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/TicketStatusUpdateTests.cs
@@ -1,0 +1,276 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+using TelecomSupportSystem.API.Controllers;
+using TelecomSupportSystem.BLL.DTOs.Tickets;
+using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities;
+using TelecomSupportSystem.DAL.Entities.Enums;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
+using Xunit;
+using NotificationType = TelecomSupportSystem.DAL.Entities.Enums.NotificationType;
+
+namespace TelecomSupportSystem.Tests.TicketT
+{
+    // PB-36 / US-60: Tehničar mijenja status tiketa koji mu je dodijeljen
+    public class TicketStatusUpdateServiceTests
+    {
+        private readonly Mock<ITicketRepository> _ticketRepositoryMock = new();
+        private readonly Mock<ITeamRepository> _teamRepoMock = new();
+        private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
+        private readonly Mock<ICommentService> _commentServiceMock = new();
+        private readonly TicketService _ticketService;
+
+        private const int TechnicianId = 7;
+        private const int CreatorId = 42;
+        private const int TicketId = 10;
+
+        public TicketStatusUpdateServiceTests()
+        {
+            _ticketService = new TicketService(
+                _ticketRepositoryMock.Object,
+                _teamRepoMock.Object,
+                _userRepoMock.Object,
+                _notificationServiceMock.Object,
+                _commentServiceMock.Object);
+        }
+
+        private static Ticket MakeAssignedTicket(
+            int assigneeId,
+            TicketStatus status = TicketStatus.OPEN) => new()
+        {
+            TicketId = TicketId,
+            Title = "Test tiket",
+            Description = "Opis",
+            CreatorId = CreatorId,
+            Status = status,
+            Priority = Priority.MEDIUM,
+            ProblemCategory = ProblemCategory.INTERNET,
+            CreatedDate = DateTime.UtcNow,
+            Assignments = new List<TicketUser>
+            {
+                new()
+                {
+                    TicketId = TicketId,
+                    UserId = assigneeId,
+                    AssignmentDate = DateTime.UtcNow,
+                    AssignmentType = AssignmentType.AUTOMATIC,
+                    User = new User { UserId = assigneeId, FirstName = "T", LastName = "T" }
+                }
+            }
+        };
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldUpdateStatusAndNotifyCreator_WhenAssignedTechnicianRequestsClosure()
+        {
+            var ticket = MakeAssignedTicket(TechnicianId, TicketStatus.OPEN);
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            await _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSURE_REQUESTED, TechnicianId, "TECHNICIAN");
+
+            ticket.Status.Should().Be(TicketStatus.CLOSURE_REQUESTED);
+            ticket.ClosureRequestedById.Should().Be(TechnicianId);
+            ticket.ClosureRequestStatus.Should().Be(ClosureRequestStatus.PENDING);
+            _ticketRepositoryMock.Verify(r => r.UpdateAsync(ticket), Times.Once);
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                CreatorId,
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                NotificationType.STATUS_CHANGED,
+                TicketId), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldThrowUnauthorized_WhenTicketNotAssignedToTechnician()
+        {
+            var ticket = MakeAssignedTicket(assigneeId: 99, TicketStatus.OPEN); // assigned to someone else
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            var act = () => _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSURE_REQUESTED, TechnicianId, "TECHNICIAN");
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _ticketRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Ticket>()), Times.Never);
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationType>(), It.IsAny<int?>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldThrowInvalidOperation_WhenTicketIsClosed()
+        {
+            var ticket = MakeAssignedTicket(TechnicianId, TicketStatus.CLOSED);
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            var act = () => _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSURE_REQUESTED, TechnicianId, "TECHNICIAN");
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            _ticketRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Ticket>()), Times.Never);
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationType>(), It.IsAny<int?>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldThrowUnauthorized_WhenRoleIsNotTechnician()
+        {
+            var act = () => _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSURE_REQUESTED, TechnicianId, "CLIENT");
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _ticketRepositoryMock.Verify(r => r.GetByIdWithDetailsAsync(It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldThrowInvalidOperation_WhenTargetStatusNotAllowed()
+        {
+            // CLOSED is not in the technician's allowed list — closure must go through client confirmation
+            var ticket = MakeAssignedTicket(TechnicianId, TicketStatus.OPEN);
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            var act = () => _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSED, TechnicianId, "TECHNICIAN");
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            _ticketRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Ticket>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldThrowKeyNotFound_WhenTicketDoesNotExist()
+        {
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync((Ticket?)null);
+
+            var act = () => _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.CLOSURE_REQUESTED, TechnicianId, "TECHNICIAN");
+
+            await act.Should().ThrowAsync<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldBeNoOp_WhenNewStatusEqualsCurrent()
+        {
+            var ticket = MakeAssignedTicket(TechnicianId, TicketStatus.OPEN);
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            await _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.OPEN, TechnicianId, "TECHNICIAN");
+
+            _ticketRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Ticket>()), Times.Never);
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationType>(), It.IsAny<int?>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateTicketStatusAsync_ShouldMarkClosureAsRejected_WhenMovingFromClosureRequestedBackToOpen()
+        {
+            var ticket = MakeAssignedTicket(TechnicianId, TicketStatus.CLOSURE_REQUESTED);
+            ticket.ClosureRequestStatus = ClosureRequestStatus.PENDING;
+            _ticketRepositoryMock.Setup(r => r.GetByIdWithDetailsAsync(TicketId)).ReturnsAsync(ticket);
+
+            await _ticketService.UpdateTicketStatusAsync(TicketId, TicketStatus.OPEN, TechnicianId, "TECHNICIAN");
+
+            ticket.Status.Should().Be(TicketStatus.OPEN);
+            ticket.ClosureRequestStatus.Should().Be(ClosureRequestStatus.REJECTED);
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                CreatorId, It.IsAny<string>(), It.IsAny<string>(),
+                NotificationType.STATUS_CHANGED, TicketId), Times.Once);
+        }
+    }
+
+    // PB-36 / US-60: Kontroler endpoint za promjenu statusa
+    public class TicketStatusUpdateControllerTests
+    {
+        private readonly Mock<ITicketService> _ticketServiceMock = new();
+        private readonly TicketController _controller;
+
+        public TicketStatusUpdateControllerTests()
+        {
+            _controller = new TicketController(_ticketServiceMock.Object);
+        }
+
+        private void SetUser(int userId, string role)
+        {
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId.ToString()),
+                new(ClaimTypes.Role, role)
+            };
+            var identity = new ClaimsIdentity(claims, "TestAuth");
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+            };
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnOk_WhenValid()
+        {
+            SetUser(7, "TECHNICIAN");
+            var dto = new UpdateTicketStatusDto { Status = TicketStatus.CLOSURE_REQUESTED };
+
+            _ticketServiceMock.Setup(s => s.UpdateTicketStatusAsync(10, dto.Status, 7, "TECHNICIAN"))
+                .Returns(Task.CompletedTask);
+
+            var result = await _controller.UpdateStatus(10, dto);
+
+            result.Should().BeOfType<OkObjectResult>();
+            _ticketServiceMock.Verify(s => s.UpdateTicketStatusAsync(10, dto.Status, 7, "TECHNICIAN"), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnForbid_WhenServiceThrowsUnauthorized()
+        {
+            SetUser(7, "TECHNICIAN");
+            var dto = new UpdateTicketStatusDto { Status = TicketStatus.CLOSURE_REQUESTED };
+
+            _ticketServiceMock.Setup(s => s.UpdateTicketStatusAsync(10, dto.Status, 7, "TECHNICIAN"))
+                .ThrowsAsync(new UnauthorizedAccessException());
+
+            var result = await _controller.UpdateStatus(10, dto);
+
+            result.Should().BeOfType<ForbidResult>();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnBadRequest_WhenServiceThrowsInvalidOperation()
+        {
+            SetUser(7, "TECHNICIAN");
+            var dto = new UpdateTicketStatusDto { Status = TicketStatus.CLOSURE_REQUESTED };
+
+            _ticketServiceMock.Setup(s => s.UpdateTicketStatusAsync(10, dto.Status, 7, "TECHNICIAN"))
+                .ThrowsAsync(new InvalidOperationException("Tiket je već zatvoren."));
+
+            var result = await _controller.UpdateStatus(10, dto);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnNotFound_WhenTicketDoesNotExist()
+        {
+            SetUser(7, "TECHNICIAN");
+            var dto = new UpdateTicketStatusDto { Status = TicketStatus.CLOSURE_REQUESTED };
+
+            _ticketServiceMock.Setup(s => s.UpdateTicketStatusAsync(999, dto.Status, 7, "TECHNICIAN"))
+                .ThrowsAsync(new KeyNotFoundException());
+
+            var result = await _controller.UpdateStatus(999, dto);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnUnauthorized_WhenNoUserClaims()
+        {
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) }
+            };
+            var dto = new UpdateTicketStatusDto { Status = TicketStatus.CLOSURE_REQUESTED };
+
+            var result = await _controller.UpdateStatus(10, dto);
+
+            result.Should().BeOfType<UnauthorizedResult>();
+        }
+    }
+}

--- a/Project/frontend/src/pages/TicketDetail.jsx
+++ b/Project/frontend/src/pages/TicketDetail.jsx
@@ -33,6 +33,7 @@ import {
     forceCloseTicket,
     getTicketRating,
     createTicketRating,
+    updateTicketStatus,
 } from '../services/ticketService'
 import { useAuth } from '../context/AuthContext'
 import Badge from '../components/common/Badge'
@@ -235,6 +236,35 @@ export default function TicketDetail() {
         rating === null &&
         !ratingModalDismissed
     ) || ratingSuccess
+
+    // PB-36 / US-60: Status promjena (tehničar)
+    const TECHNICIAN_STATUSES = [
+        { value: 'OPEN', label: 'U toku (Otvoren)' },
+        { value: 'CLOSURE_REQUESTED', label: 'Čeka zatvaranje' },
+    ]
+    const [statusUpdating, setStatusUpdating] = useState(false)
+    const [statusNotification, setStatusNotification] = useState(null)
+
+    const handleUpdateTicketStatus = async (newStatus) => {
+        if (!newStatus || newStatus === ticket?.status) return
+        setStatusUpdating(true)
+        setStatusNotification(null)
+        try {
+            await updateTicketStatus(Number(id), newStatus)
+            const updatedTicket = await getTicketById(Number(id))
+            setTicket(updatedTicket)
+            setStatusNotification({ type: 'success', message: 'Status tiketa je uspješno ažuriran.' })
+        } catch (err) {
+            console.error('Failed to update ticket status', err)
+            setStatusNotification({
+                type: 'error',
+                message: err.response?.data?.poruka || 'Greška pri ažuriranju statusa tiketa.',
+            })
+        } finally {
+            setStatusUpdating(false)
+            setTimeout(() => setStatusNotification(null), 3000)
+        }
+    }
 
     const INTERNAL_PRIORITIES = [
         { value: 1, key: 'LOW', label: 'Nizak' },
@@ -727,6 +757,45 @@ export default function TicketDetail() {
                                     </button>
                                 )}
                             </>
+                        )}
+                    </div>
+                )}
+
+                {/* PB-36 / US-60: Tehničar mijenja status tiketa koji mu je dodijeljen */}
+                {user?.role === 'TECHNICIAN'
+                    && ticket.status !== 'CLOSED'
+                    && ticket.assignedAgentId === user?.userId && (
+                    <div className="border-t border-gray-100 mt-5 pt-4">
+                        <div className="flex flex-col sm:flex-row sm:items-end gap-3">
+                            <div className="flex-1">
+                                <p className="text-xs text-gray-500 mb-2 uppercase tracking-wide font-medium">
+                                    Promijeni status tiketa
+                                </p>
+                                <select
+                                    aria-label="Promijeni status tiketa"
+                                    disabled={statusUpdating}
+                                    value={ticket.status || ''}
+                                    onChange={(e) => handleUpdateTicketStatus(e.target.value)}
+                                    className="w-full sm:w-72 px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white outline-none focus:ring-2 focus:ring-navy-500 disabled:opacity-50"
+                                >
+                                    {TECHNICIAN_STATUSES.map((s) => (
+                                        <option key={s.value} value={s.value}>{s.label}</option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+
+                        {statusNotification && (
+                            <div
+                                role="status"
+                                className={`mt-3 p-3 rounded-lg text-xs font-medium ${
+                                    statusNotification.type === 'success'
+                                        ? 'bg-green-50 text-green-700 border border-green-100'
+                                        : 'bg-red-50 text-red-700 border border-red-100'
+                                }`}
+                            >
+                                {statusNotification.message}
+                            </div>
                         )}
                     </div>
                 )}

--- a/Project/frontend/src/services/ticketService.js
+++ b/Project/frontend/src/services/ticketService.js
@@ -77,6 +77,12 @@ export async function updateInternalPriority(ticketId, priority) {
   return response.data
 }
 
+// PB-36 / US-60: Tehničar mijenja status tiketa koji mu je dodijeljen
+export async function updateTicketStatus(ticketId, status) {
+  const response = await api.post(`/tickets/${ticketId}/status`, { status })
+  return response.data
+}
+
 // Closure Workflow
 export async function closeTicket(ticketId) {
   const response = await api.post(`/tickets/${ticketId}/close`)

--- a/Sprint8/AIUsageLog.md
+++ b/Sprint8/AIUsageLog.md
@@ -88,3 +88,21 @@ AI Usage Log ne sluzi za kaznjavanje koristenja AI, nego za transparentnost i pr
 | Sta je tim odbacio | Prijedloge za anonimno ocjenjivanje i posebnu stranicu za sve ocjene, jer nisu dio trenutnog scope-a PB-26. Odbaceno je i omogucavanje izmjene ocjene nakon slanja, zbog acceptance kriterija da isti tiket ne smije biti ocijenjen vise puta. |
 | Rizici, problemi ili greske koje su uocene | Potrebno je pazljivo validirati vlasnistvo tiketa i status `Closed`, jer bi propust omogucio ocjenjivanje tudjih ili nezatvorenih tiketa. Postoji rizik od duplog slanja forme na frontendu, pa backend validacija jedinstvene ocjene ostaje obavezna zastita. |
 | Ko je koristio alat | Ajnur Kusundzija |
+
+---
+
+## Unos #5
+
+| Polje | Detalji |
+|---|---|
+| Datum | 17.05.2026 |
+| Sprint broj | Sprint 8 |
+| Alat koji je koristen | Claude Code (claude-opus-4-7) |
+| Svrha koristenja | Implementacija PB-36 / US-60: Azuriranje statusa tiketa od strane tehnicara |
+| Kratak opis zadatka ili upita | Implementirati backend i frontend tako da tehnicar moze promijeniti status tiketa koji mu je dodijeljen, uz postovanje pravila pristupa (samo dodijeljeni tehnicar, samo otvoreni tiketi, predefinisani dozvoljeni statusi), generisanje `STATUS_CHANGED` notifikacije za kreatora tiketa i prikaz potvrde uspjeha — bez narusavanja postojecih tokova (closure workflow, forwarding, notifikacije). |
+| Sta je AI predlozio ili generisao | Backend: novi `UpdateTicketStatusDto` (TicketStatus enum), prosirenje `ITicketService` i `TicketService` metodom `UpdateTicketStatusAsync(ticketId, newStatus, userId, role)` sa svim biznis pravilima (role == TECHNICIAN, posljednji assignee == current user, ticket != CLOSED, novi status u dozvoljenoj listi `{OPEN, CLOSURE_REQUESTED}`, no-op kada je isti status, postavljanje `ClosureRequested*` polja pri prelasku na CLOSURE_REQUESTED, postavljanje `ClosureRequestStatus = REJECTED` pri povratku na OPEN), novi endpoint `POST /api/tickets/{id}/status` u `TicketController`-u koji mapira izuzetke na 404/403/400, prosirenje `TicketDetailDto` sa `AssignedAgentId` (potrebno da frontend zna treba li prikazati kontrolu), 13 jedinicnih testova u `TicketStatusUpdateTests.cs` (servis: uspjesna promjena + notifikacija, zabrana neasignuee/closed/non-technician/non-allowed-status, KeyNotFound, no-op, REJECTED tranzicija; kontroler: 200/403/400/404/401 mapiranja). Frontend: `updateTicketStatus` u `ticketService.js`, mali dropdown blok u `TicketDetail.jsx` koji se prikazuje samo kada je `user.role === 'TECHNICIAN' && ticket.status !== 'CLOSED' && ticket.assignedAgentId === user.userId`, inline success/error poruka, osvjezavanje stanja tiketa bez full reloada. |
+| Sta je tim prihvatio | Cjelokupnu backend arhitekturu (DTO, servisnu metodu sa svim validacijama, kontroler endpoint, prosirenje TicketDetailDto sa AssignedAgentId), sve testove, frontend dropdown UI i logiku osvjezavanja stanja. |
+| Sta je tim izmijenio | Nista strukturalno — implementacija je prihvacena nakon ručne provjere end-to-end toka kroz UI (klijent kreira tiket → agent prosljedjuje tehnicaru → tehnicar mijenja status → klijent dobija STATUS_CHANGED notifikaciju). |
+| Sta je tim odbacio | Prijedlog da se prosiri `TicketStatus` enum sa dodatnim vrijednostima tipa `IN_PROGRESS`/`PENDING` — odbaceno jer bi zahtijevalo EF migraciju, novu logiku u svim postojecim filterima/statistikama i nije nuzno za AC. Takodjer odbaceno dozvoljavanje tehnicaru da direktno postavi `CLOSED` — zatvaranje u ovom sistemu mora ici kroz client-confirm tok (`request-closure` → `accept-closure`). |
+| Rizici, problemi ili greske koje su uocene | UI guard (`assignedAgentId === user.userId`) sakriva kontrolu od tehnicara koji nisu trenutni assignee, ali backend takodjer provjerava — bez backend provjere kontrola bi se mogla zaobici direktnim API pozivom. Postojeci `GetTicketByIdAsync` za TECHNICIAN-a dozvoljava pristup ako je IKAD bio dodijeljen (`Assignments.Any(a => a.UserId == userId)`), sto znaci da bivsi assignee moze otvoriti detalj, ali nasa provjera "posljednji assignee" u `UpdateTicketStatusAsync` ispravno odbija takvog korisnika. Zabilezeni postojeci CS8602 warning u `TicketService.cs:271` i nedostatak assignee-provjere u `CloseTicketAsync` — oba su van scope-a US-60. |
+| Ko je koristio alat | Ajnur Kusundzija |

--- a/Sprint8/SprintBacklog.md
+++ b/Sprint8/SprintBacklog.md
@@ -15,7 +15,7 @@ Implementirati sistem notifikacija koji obavještava korisnike o događajima na 
 | ID | Naziv zadatka ili storyja | Povezani US | Odgovorna osoba ili osobe | Status | Napomena |
 |---|---|---|---|---|---|
 | SB-01 | PB-49 Notifikacije | US-58, US-59 | Uma | Done | Implementacija slanja i prikaza notifikacija za sve role, real-time via SignalR |
-| SB-02 | PB-36 Ažuriranje statusa tiketa | US-60 | Ajnur | To-Do | Tehničar mijenja status tiketa koji mu je dodijeljen |
+| SB-02 | PB-36 Ažuriranje statusa tiketa | US-60 | Ajnur | Done | Tehničar mijenja status tiketa koji mu je dodijeljen |
 | SB-03 | PB-26 Ocjenjivanje tiketa | US-61 | Ajnur | Done | Korisnik ocjenjuje kvalitet rješenja nakon zatvaranja tiketa |
 | SB-04 | PB-42 Statistika agenta i tehničara | US-62, US-63 | Uma | Done | Prikaz lične statistike rada na dashboardu |
 | SB-05 | PB-20 Upravljanje korisničkim profilom | US-64, US-65 | Merisa | To-Do | Korisnik mijenja email i lozinku svog profila |


### PR DESCRIPTION
Feature/pb 36: tehničar mijenja status tiketa

- Backend: POST /api/tickets/{id}/status sa validacijama
  (samo TECHNICIAN, mora biti posljednji assignee, tiket != CLOSED,
  dozvoljeni statusi: OPEN, CLOSURE_REQUESTED)
- STATUS_CHANGED notifikacija za kreatora preko postojećeg
  NotificationService toka
- TicketDetailDto: dodan AssignedAgentId za frontend guard
- Frontend: dropdown za promjenu statusa u TicketDetail vidljiv
  samo dodijeljenom tehničaru na otvorenom tiketu, inline potvrda
- 13 novih testova (servis + kontroler), svi prolaze (236/236) backend
- Sprint backlog: SB-02 → Done, AI Usage Log: Unos #5