### PR TITLE
PB6162

### DIFF
--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/FaqController.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/FaqController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using TelecomSupportSystem.BLL.DTOs.Faq;
 using TelecomSupportSystem.BLL.Services.Interfaces;
 
 namespace TelecomSupportSystem.API.Controllers
@@ -16,11 +17,73 @@ namespace TelecomSupportSystem.API.Controllers
             _faqService = faqService;
         }
 
+        // Read-only lista za sve prijavljene korisnike — vraća samo aktivne FAQ stavke
         [HttpGet]
         public async Task<IActionResult> GetFaqs()
         {
             var faqs = await _faqService.GetFaqsAsync();
             return Ok(faqs);
+        }
+
+        // PB-61 / US-104: Admin lista (uključuje neaktivne — koristi se u admin sekciji)
+        [HttpGet("all")]
+        [Authorize(Roles = "ADMINISTRATOR")]
+        public async Task<IActionResult> GetAllFaqs()
+        {
+            var faqs = await _faqService.GetAllFaqsAsync();
+            return Ok(faqs);
+        }
+
+        // PB-61 / US-104: Admin kreira novu FAQ stavku
+        [HttpPost]
+        [Authorize(Roles = "ADMINISTRATOR")]
+        public async Task<IActionResult> CreateFaq([FromBody] CreateFaqDto dto)
+        {
+            try
+            {
+                var created = await _faqService.CreateFaqAsync(dto);
+                return CreatedAtAction(nameof(GetFaqs), new { id = created.FaqId }, created);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { poruka = ex.Message });
+            }
+        }
+
+        // PB-61 / US-104: Admin uređuje postojeću FAQ stavku
+        [HttpPut("{id:int}")]
+        [Authorize(Roles = "ADMINISTRATOR")]
+        public async Task<IActionResult> UpdateFaq(int id, [FromBody] UpdateFaqDto dto)
+        {
+            try
+            {
+                var updated = await _faqService.UpdateFaqAsync(id, dto);
+                return Ok(updated);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { poruka = ex.Message });
+            }
+            catch (KeyNotFoundException)
+            {
+                return NotFound();
+            }
+        }
+
+        // PB-61 / US-104: Admin briše FAQ stavku
+        [HttpDelete("{id:int}")]
+        [Authorize(Roles = "ADMINISTRATOR")]
+        public async Task<IActionResult> DeleteFaq(int id)
+        {
+            try
+            {
+                await _faqService.DeleteFaqAsync(id);
+                return NoContent();
+            }
+            catch (KeyNotFoundException)
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/TicketController.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.API/Controllers/TicketController.cs
@@ -253,6 +253,39 @@ namespace TelecomSupportSystem.API.Controllers
             }
         }
 
+        // PB-62 / US-105: POST /api/tickets/{id}/self-assign
+        // Agent jednim klikom preuzima nedodijeljeni tiket sebi
+        [HttpPost("{id:int}/self-assign")]
+        public async Task<IActionResult> SelfAssignTicket(int id)
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var role = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (userIdClaim is null || !int.TryParse(userIdClaim, out int userId) || role is null)
+                return Unauthorized();
+
+            if (role != "AGENT")
+                return Forbid();
+
+            try
+            {
+                var result = await _ticketService.SelfAssignTicketAsync(id, userId);
+                return Ok(result);
+            }
+            catch (KeyNotFoundException)
+            {
+                return NotFound();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { poruka = ex.Message });
+            }
+        }
+
         // POST /api/tickets/{id}/internal-priority
         [HttpPost("{id:int}/internal-priority")]
         public async Task<IActionResult> UpdateInternalPriority(int id, [FromBody] UpdateInternalPriorityDto dto)

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Faq/CreateFaqDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Faq/CreateFaqDto.cs
@@ -1,0 +1,10 @@
+namespace TelecomSupportSystem.BLL.DTOs.Faq
+{
+    public class CreateFaqDto
+    {
+        public string Question { get; set; } = string.Empty;
+        public string Answer { get; set; } = string.Empty;
+        public string? Category { get; set; }
+        public int SortOrder { get; set; }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Faq/UpdateFaqDto.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/DTOs/Faq/UpdateFaqDto.cs
@@ -1,0 +1,10 @@
+namespace TelecomSupportSystem.BLL.DTOs.Faq
+{
+    public class UpdateFaqDto
+    {
+        public string Question { get; set; } = string.Empty;
+        public string Answer { get; set; } = string.Empty;
+        public string? Category { get; set; }
+        public int SortOrder { get; set; }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/FaqService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/FaqService.cs
@@ -1,11 +1,16 @@
 using TelecomSupportSystem.BLL.DTOs.Faq;
 using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities;
 using TelecomSupportSystem.DAL.Repositories.Interfaces;
 
 namespace TelecomSupportSystem.BLL.Services
 {
     public class FaqService : IFaqService
     {
+        // PB-61: konzistentne poruke validacije
+        public const string QuestionRequiredMessage = "Pitanje ne smije biti prazno.";
+        public const string AnswerRequiredMessage = "Odgovor ne smije biti prazan.";
+
         private readonly IFaqRepository _faqRepository;
 
         public FaqService(IFaqRepository faqRepository)
@@ -17,14 +22,74 @@ namespace TelecomSupportSystem.BLL.Services
         {
             var faqs = await _faqRepository.GetActiveAsync();
 
-            return faqs.Select(faq => new GetFaqDto
-            {
-                FaqId = faq.FaqId,
-                Question = faq.Question,
-                Answer = faq.Answer,
-                Category = faq.Category,
-                SortOrder = faq.SortOrder
-            });
+            return faqs.Select(MapToDto);
         }
+
+        public async Task<IEnumerable<GetFaqDto>> GetAllFaqsAsync()
+        {
+            var faqs = await _faqRepository.GetAllAsync();
+
+            return faqs.Select(MapToDto);
+        }
+
+        public async Task<GetFaqDto> CreateFaqAsync(CreateFaqDto dto)
+        {
+            ValidateContent(dto.Question, dto.Answer);
+
+            var faq = new Faq
+            {
+                Question = dto.Question.Trim(),
+                Answer = dto.Answer.Trim(),
+                Category = string.IsNullOrWhiteSpace(dto.Category) ? null : dto.Category.Trim(),
+                SortOrder = dto.SortOrder,
+                IsActive = true,
+                CreatedDate = DateTime.UtcNow
+            };
+
+            var created = await _faqRepository.CreateAsync(faq);
+            return MapToDto(created);
+        }
+
+        public async Task<GetFaqDto> UpdateFaqAsync(int faqId, UpdateFaqDto dto)
+        {
+            ValidateContent(dto.Question, dto.Answer);
+
+            var faq = await _faqRepository.GetByIdAsync(faqId)
+                ?? throw new KeyNotFoundException($"FAQ stavka {faqId} nije pronađena.");
+
+            faq.Question = dto.Question.Trim();
+            faq.Answer = dto.Answer.Trim();
+            faq.Category = string.IsNullOrWhiteSpace(dto.Category) ? null : dto.Category.Trim();
+            faq.SortOrder = dto.SortOrder;
+
+            await _faqRepository.UpdateAsync(faq);
+            return MapToDto(faq);
+        }
+
+        public async Task DeleteFaqAsync(int faqId)
+        {
+            var faq = await _faqRepository.GetByIdAsync(faqId)
+                ?? throw new KeyNotFoundException($"FAQ stavka {faqId} nije pronađena.");
+
+            await _faqRepository.DeleteAsync(faq);
+        }
+
+        private static void ValidateContent(string question, string answer)
+        {
+            if (string.IsNullOrWhiteSpace(question))
+                throw new ArgumentException(QuestionRequiredMessage);
+
+            if (string.IsNullOrWhiteSpace(answer))
+                throw new ArgumentException(AnswerRequiredMessage);
+        }
+
+        private static GetFaqDto MapToDto(Faq faq) => new()
+        {
+            FaqId = faq.FaqId,
+            Question = faq.Question,
+            Answer = faq.Answer,
+            Category = faq.Category,
+            SortOrder = faq.SortOrder
+        };
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IFaqService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/IFaqService.cs
@@ -5,5 +5,14 @@ namespace TelecomSupportSystem.BLL.Services.Interfaces
     public interface IFaqService
     {
         Task<IEnumerable<GetFaqDto>> GetFaqsAsync();
+
+        // PB-61: Admin lista — uključuje neaktivne stavke
+        Task<IEnumerable<GetFaqDto>> GetAllFaqsAsync();
+
+        Task<GetFaqDto> CreateFaqAsync(CreateFaqDto dto);
+
+        Task<GetFaqDto> UpdateFaqAsync(int faqId, UpdateFaqDto dto);
+
+        Task DeleteFaqAsync(int faqId);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ITicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/Interfaces/ITicketService.cs
@@ -37,6 +37,9 @@ namespace TelecomSupportSystem.BLL.Services.Interfaces
         // US-TechnicianForwarding: Proslijedi tiket tehničaru na lokaciji kreatora tiketa
         Task<AgentScoreDto> ForwardTicketToTechnicianAsync(int ticketId, int currentAgentId);
 
+        // PB-62 / US-105: Agent jednim klikom preuzima nedodijeljeni tiket sebi
+        Task<AgentScoreDto> SelfAssignTicketAsync(int ticketId, int agentId);
+
         // Internal Priority Management
         Task UpdateInternalPriorityAsync(int ticketId, InternalPriority priority, int userId, string role);
 

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.BLL/Services/TicketService.cs
@@ -739,6 +739,75 @@ namespace TelecomSupportSystem.BLL.Services
             return targetScore;
         }
 
+        // PB-62 / US-105: Agent jednim klikom preuzima nedodijeljeni tiket sebi.
+        // Dozvoljeno samo kada tiket nije zatvoren i nema nijednu postojeću dodjelu.
+        public async Task<AgentScoreDto> SelfAssignTicketAsync(int ticketId, int agentId)
+        {
+            var ticket = await _ticketRepository.GetByIdWithDetailsAsync(ticketId)
+                ?? throw new KeyNotFoundException($"Tiket {ticketId} nije pronađen.");
+
+            if (ticket.Status == TicketStatus.CLOSED)
+                throw new InvalidOperationException("Zatvoreni tiket se ne može preuzeti.");
+
+            if (ticket.Assignments.Any())
+                throw new InvalidOperationException("Tiket je već dodijeljen drugom agentu.");
+
+            var agent = await _userRepository.GetByIdAsync(agentId)
+                ?? throw new KeyNotFoundException($"Agent {agentId} nije pronađen.");
+
+            if (agent.Role != Role.AGENT)
+                throw new UnauthorizedAccessException("Samo agent može preuzeti tiket.");
+
+            var teamId = agent.TeamId ?? ticket.TeamId;
+            if (teamId is null)
+                throw new InvalidOperationException("Agent nema dodijeljen tim — preuzimanje nije moguće.");
+
+            var newAssignment = new TicketUser
+            {
+                TicketId       = ticketId,
+                UserId         = agent.UserId,
+                TeamId         = teamId.Value,
+                AssignmentDate = DateTime.UtcNow,
+                AssignmentType = AssignmentType.MANUAL,
+                Note           = "Agent samodjelovanje tiketa"
+            };
+
+            if (agent.TeamId.HasValue)
+                ticket.TeamId = agent.TeamId;
+
+            await _ticketRepository.AddAssignmentAsync(newAssignment);
+
+            await _commentService.AddSystemCommentAsync(
+                ticketId,
+                $"Tiket je preuzeo agent: {agent.FirstName} {agent.LastName}");
+
+            await _notificationService.SendNotificationAsync(
+                ticket.CreatorId,
+                "Tiket dodijeljen agentu",
+                $"Vaš tiket \"{ticket.Title}\" je preuzeo agent {agent.FirstName} {agent.LastName}.",
+                NotificationType.TICKET_ASSIGNED,
+                ticket.TicketId);
+
+            if (_auditLogService is not null)
+            {
+                await _auditLogService.LogAsync(
+                    AuditActionType.TICKET_FORWARDED,
+                    "Ticket",
+                    ticket.TicketId.ToString(),
+                    $"Tiket #{ticket.TicketId} preuzeo agent {agent.FirstName} {agent.LastName} (samodjelovanje)",
+                    userId: agentId,
+                    oldValue: new { userId = (int?)null },
+                    newValue: new { userId = agent.UserId, teamId = teamId });
+            }
+
+            return new AgentScoreDto
+            {
+                UserId   = agent.UserId,
+                FullName = $"{agent.FirstName} {agent.LastName}",
+                ScorePercent = 100
+            };
+        }
+
         // US-TechnicianForwarding: Proslijedi tiket tehničaru na lokaciji kreatora tiketa
         public async Task<AgentScoreDto> ForwardTicketToTechnicianAsync(int ticketId, int currentAgentId)
         {

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/FaqRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/FaqRepository.cs
@@ -22,5 +22,38 @@ namespace TelecomSupportSystem.DAL.Repositories
                 .ThenBy(faq => faq.FaqId)
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<Faq>> GetAllAsync()
+        {
+            return await _context.Faqs
+                .AsNoTracking()
+                .OrderBy(faq => faq.SortOrder)
+                .ThenBy(faq => faq.FaqId)
+                .ToListAsync();
+        }
+
+        public async Task<Faq?> GetByIdAsync(int faqId)
+        {
+            return await _context.Faqs.FirstOrDefaultAsync(faq => faq.FaqId == faqId);
+        }
+
+        public async Task<Faq> CreateAsync(Faq faq)
+        {
+            _context.Faqs.Add(faq);
+            await _context.SaveChangesAsync();
+            return faq;
+        }
+
+        public async Task UpdateAsync(Faq faq)
+        {
+            _context.Faqs.Update(faq);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Faq faq)
+        {
+            _context.Faqs.Remove(faq);
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/IFaqRepository.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.DAL/Repositories/Interfaces/IFaqRepository.cs
@@ -5,5 +5,16 @@ namespace TelecomSupportSystem.DAL.Repositories.Interfaces
     public interface IFaqRepository
     {
         Task<IEnumerable<Faq>> GetActiveAsync();
+
+        // PB-61: Admin pregled — sve FAQ stavke (uključujući neaktivne)
+        Task<IEnumerable<Faq>> GetAllAsync();
+
+        Task<Faq?> GetByIdAsync(int faqId);
+
+        Task<Faq> CreateAsync(Faq faq);
+
+        Task UpdateAsync(Faq faq);
+
+        Task DeleteAsync(Faq faq);
     }
 }

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Faq/FaqAdminCrudTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Faq/FaqAdminCrudTests.cs
@@ -1,0 +1,259 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using TelecomSupportSystem.API.Controllers;
+using TelecomSupportSystem.BLL.DTOs.Faq;
+using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
+using Xunit;
+
+namespace TelecomSupportSystem.Tests.Faq
+{
+    // PB-61 / US-104: Admin CRUD nad FAQ stavkama.
+    // Pokriva: validaciju praznih polja, mapiranje DTO → entity, autorizaciju controller-a,
+    // ne-postojeću FAQ stavku i admin-only endpointe.
+    public class FaqAdminCrudTests
+    {
+        private readonly Mock<IFaqRepository> _faqRepositoryMock = new();
+        private readonly FaqService _faqService;
+
+        public FaqAdminCrudTests()
+        {
+            _faqService = new FaqService(_faqRepositoryMock.Object);
+        }
+
+        // ─── Service: CREATE ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task CreateFaqAsync_ShouldThrow_WhenQuestionIsEmpty()
+        {
+            var dto = new CreateFaqDto { Question = "   ", Answer = "Validan odgovor" };
+
+            var act = () => _faqService.CreateFaqAsync(dto);
+
+            (await act.Should().ThrowAsync<ArgumentException>())
+                .WithMessage(FaqService.QuestionRequiredMessage);
+            _faqRepositoryMock.Verify(r => r.CreateAsync(It.IsAny<DAL.Entities.Faq>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CreateFaqAsync_ShouldThrow_WhenAnswerIsEmpty()
+        {
+            var dto = new CreateFaqDto { Question = "Validno pitanje?", Answer = "" };
+
+            var act = () => _faqService.CreateFaqAsync(dto);
+
+            (await act.Should().ThrowAsync<ArgumentException>())
+                .WithMessage(FaqService.AnswerRequiredMessage);
+        }
+
+        [Fact]
+        public async Task CreateFaqAsync_ShouldPersistTrimmedFaq_WhenInputIsValid()
+        {
+            _faqRepositoryMock
+                .Setup(r => r.CreateAsync(It.IsAny<DAL.Entities.Faq>()))
+                .ReturnsAsync((DAL.Entities.Faq f) => { f.FaqId = 42; return f; });
+
+            var dto = new CreateFaqDto
+            {
+                Question = "  Kako resetovati ruter?  ",
+                Answer = "  Isključite ga 30 sekundi.  ",
+                Category = "  Internet  ",
+                SortOrder = 5
+            };
+
+            var result = await _faqService.CreateFaqAsync(dto);
+
+            result.FaqId.Should().Be(42);
+            result.Question.Should().Be("Kako resetovati ruter?");
+            result.Answer.Should().Be("Isključite ga 30 sekundi.");
+            result.Category.Should().Be("Internet");
+            result.SortOrder.Should().Be(5);
+            _faqRepositoryMock.Verify(r => r.CreateAsync(It.Is<DAL.Entities.Faq>(
+                f => f.Question == "Kako resetovati ruter?"
+                  && f.Answer == "Isključite ga 30 sekundi."
+                  && f.Category == "Internet"
+                  && f.IsActive == true)), Times.Once);
+        }
+
+        // ─── Service: UPDATE ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task UpdateFaqAsync_ShouldThrowKeyNotFound_WhenFaqDoesNotExist()
+        {
+            _faqRepositoryMock.Setup(r => r.GetByIdAsync(99))
+                .ReturnsAsync((DAL.Entities.Faq?)null);
+
+            var act = () => _faqService.UpdateFaqAsync(99, new UpdateFaqDto { Question = "Q", Answer = "A" });
+
+            await act.Should().ThrowAsync<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public async Task UpdateFaqAsync_ShouldThrow_WhenQuestionIsEmpty()
+        {
+            var dto = new UpdateFaqDto { Question = "", Answer = "ok" };
+
+            var act = () => _faqService.UpdateFaqAsync(1, dto);
+
+            (await act.Should().ThrowAsync<ArgumentException>())
+                .WithMessage(FaqService.QuestionRequiredMessage);
+        }
+
+        [Fact]
+        public async Task UpdateFaqAsync_ShouldPersistChanges_WhenInputIsValid()
+        {
+            var existing = new DAL.Entities.Faq
+            {
+                FaqId = 7,
+                Question = "Staro pitanje",
+                Answer = "Stari odgovor",
+                Category = "Stari",
+                SortOrder = 1,
+                IsActive = true
+            };
+            _faqRepositoryMock.Setup(r => r.GetByIdAsync(7)).ReturnsAsync(existing);
+
+            var dto = new UpdateFaqDto
+            {
+                Question = "Novo pitanje?",
+                Answer = "Novi odgovor.",
+                Category = "Novi",
+                SortOrder = 3
+            };
+
+            var result = await _faqService.UpdateFaqAsync(7, dto);
+
+            result.Question.Should().Be("Novo pitanje?");
+            result.Answer.Should().Be("Novi odgovor.");
+            result.Category.Should().Be("Novi");
+            result.SortOrder.Should().Be(3);
+            _faqRepositoryMock.Verify(r => r.UpdateAsync(existing), Times.Once);
+        }
+
+        // ─── Service: DELETE ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task DeleteFaqAsync_ShouldThrowKeyNotFound_WhenFaqDoesNotExist()
+        {
+            _faqRepositoryMock.Setup(r => r.GetByIdAsync(123))
+                .ReturnsAsync((DAL.Entities.Faq?)null);
+
+            var act = () => _faqService.DeleteFaqAsync(123);
+
+            await act.Should().ThrowAsync<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public async Task DeleteFaqAsync_ShouldRemove_WhenFaqExists()
+        {
+            var existing = new DAL.Entities.Faq { FaqId = 5, Question = "Q", Answer = "A" };
+            _faqRepositoryMock.Setup(r => r.GetByIdAsync(5)).ReturnsAsync(existing);
+
+            await _faqService.DeleteFaqAsync(5);
+
+            _faqRepositoryMock.Verify(r => r.DeleteAsync(existing), Times.Once);
+        }
+
+        // ─── Service: GET ALL ────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task GetAllFaqsAsync_ShouldReturnInactiveAndActive()
+        {
+            var faqs = new List<DAL.Entities.Faq>
+            {
+                new() { FaqId = 1, Question = "A?", Answer = "1", IsActive = true,  SortOrder = 1 },
+                new() { FaqId = 2, Question = "B?", Answer = "2", IsActive = false, SortOrder = 2 },
+            };
+            _faqRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(faqs);
+
+            var result = (await _faqService.GetAllFaqsAsync()).ToList();
+
+            result.Should().HaveCount(2);
+            result.Select(f => f.FaqId).Should().Equal(1, 2);
+        }
+
+        // ─── Controller: authorization metadata ──────────────────────────────────────
+
+        [Theory]
+        [InlineData(nameof(FaqController.CreateFaq))]
+        [InlineData(nameof(FaqController.UpdateFaq))]
+        [InlineData(nameof(FaqController.DeleteFaq))]
+        [InlineData(nameof(FaqController.GetAllFaqs))]
+        public void AdminEndpoints_ShouldRequireAdministratorRole(string methodName)
+        {
+            var method = typeof(FaqController).GetMethod(methodName);
+            method.Should().NotBeNull();
+
+            var authorize = method!
+                .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
+                .Cast<AuthorizeAttribute>()
+                .ToList();
+
+            authorize.Should().NotBeEmpty();
+            authorize.Should().Contain(a => a.Roles == "ADMINISTRATOR");
+        }
+
+        [Fact]
+        public void GetFaqs_ShouldNotRequireAdministratorRole()
+        {
+            var method = typeof(FaqController).GetMethod(nameof(FaqController.GetFaqs));
+            method.Should().NotBeNull();
+
+            // GET / nema role-specific [Authorize] — pristup imaju svi prijavljeni korisnici
+            var authorizeWithRoles = method!
+                .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
+                .Cast<AuthorizeAttribute>()
+                .Where(a => !string.IsNullOrEmpty(a.Roles))
+                .ToList();
+
+            authorizeWithRoles.Should().BeEmpty();
+        }
+
+        // ─── Controller: behavior via mocked service ─────────────────────────────────
+
+        [Fact]
+        public async Task CreateFaq_ShouldReturnBadRequest_WhenServiceThrowsArgumentException()
+        {
+            var serviceMock = new Mock<IFaqService>();
+            serviceMock.Setup(s => s.CreateFaqAsync(It.IsAny<CreateFaqDto>()))
+                .ThrowsAsync(new ArgumentException("Pitanje ne smije biti prazno."));
+
+            var controller = new FaqController(serviceMock.Object);
+
+            var result = await controller.CreateFaq(new CreateFaqDto());
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Fact]
+        public async Task UpdateFaq_ShouldReturnNotFound_WhenServiceThrowsKeyNotFound()
+        {
+            var serviceMock = new Mock<IFaqService>();
+            serviceMock.Setup(s => s.UpdateFaqAsync(99, It.IsAny<UpdateFaqDto>()))
+                .ThrowsAsync(new KeyNotFoundException());
+
+            var controller = new FaqController(serviceMock.Object);
+
+            var result = await controller.UpdateFaq(99, new UpdateFaqDto { Question = "Q", Answer = "A" });
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public async Task DeleteFaq_ShouldReturnNoContent_OnSuccess()
+        {
+            var serviceMock = new Mock<IFaqService>();
+            serviceMock.Setup(s => s.DeleteFaqAsync(7)).Returns(Task.CompletedTask);
+
+            var controller = new FaqController(serviceMock.Object);
+
+            var result = await controller.DeleteFaq(7);
+
+            result.Should().BeOfType<NoContentResult>();
+            serviceMock.Verify(s => s.DeleteFaqAsync(7), Times.Once);
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/FaqAdminCrudIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/FaqAdminCrudIntegrationTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TelecomSupportSystem.API.Controllers;
+using TelecomSupportSystem.BLL.DTOs.Faq;
+using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.DAL;
+using TelecomSupportSystem.DAL.Repositories;
+using Xunit;
+
+namespace TelecomSupportSystem.Tests.Integration
+{
+    // PB-61 / US-104: End-to-end testovi Controller → Service → Repository → DB (InMemory)
+    // za admin CRUD nad FAQ stavkama.
+    public class FaqAdminCrudIntegrationTests
+    {
+        private static ApplicationDbContext CreateDbContext() =>
+            new(new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        private static FaqController CreateController(ApplicationDbContext context)
+            => new(new FaqService(new FaqRepository(context)));
+
+        [Fact]
+        public async Task CreateFaq_ShouldPersistAndBeVisibleInPublicList()
+        {
+            using var context = CreateDbContext();
+            var controller = CreateController(context);
+
+            var createResult = await controller.CreateFaq(new CreateFaqDto
+            {
+                Question = "Kako provjeriti račun?",
+                Answer = "Otvorite korisnički portal.",
+                Category = "Računi",
+                SortOrder = 1
+            });
+
+            createResult.Should().BeOfType<CreatedAtActionResult>();
+
+            var publicResult = await controller.GetFaqs();
+            var publicOk = publicResult.Should().BeOfType<OkObjectResult>().Subject;
+            var body = publicOk.Value.Should().BeAssignableTo<IEnumerable<GetFaqDto>>().Subject.ToList();
+            body.Should().ContainSingle(f => f.Question == "Kako provjeriti račun?");
+        }
+
+        [Fact]
+        public async Task CreateFaq_ShouldReturnBadRequest_WhenQuestionIsEmpty()
+        {
+            using var context = CreateDbContext();
+            var controller = CreateController(context);
+
+            var result = await controller.CreateFaq(new CreateFaqDto
+            {
+                Question = "   ",
+                Answer = "Neki odgovor"
+            });
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+            (await context.Faqs.CountAsync()).Should().Be(0);
+        }
+
+        [Fact]
+        public async Task CreateFaq_ShouldReturnBadRequest_WhenAnswerIsEmpty()
+        {
+            using var context = CreateDbContext();
+            var controller = CreateController(context);
+
+            var result = await controller.CreateFaq(new CreateFaqDto
+            {
+                Question = "Validno pitanje?",
+                Answer = ""
+            });
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Fact]
+        public async Task UpdateFaq_ShouldPersistChanges()
+        {
+            using var context = CreateDbContext();
+            context.Faqs.Add(new DAL.Entities.Faq
+            {
+                Question = "Staro?",
+                Answer = "Stari",
+                Category = "Cat",
+                SortOrder = 1,
+                IsActive = true,
+                CreatedDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+
+            var faqId = context.Faqs.First().FaqId;
+            var controller = CreateController(context);
+
+            var updateResult = await controller.UpdateFaq(faqId, new UpdateFaqDto
+            {
+                Question = "Novo?",
+                Answer = "Novi odgovor",
+                Category = "Cat2",
+                SortOrder = 9
+            });
+
+            var ok = updateResult.Should().BeOfType<OkObjectResult>().Subject;
+            var dto = ok.Value.Should().BeOfType<GetFaqDto>().Subject;
+            dto.Question.Should().Be("Novo?");
+            dto.SortOrder.Should().Be(9);
+
+            var refreshed = await context.Faqs.AsNoTracking().FirstAsync(f => f.FaqId == faqId);
+            refreshed.Question.Should().Be("Novo?");
+            refreshed.Category.Should().Be("Cat2");
+        }
+
+        [Fact]
+        public async Task UpdateFaq_ShouldReturnNotFound_WhenFaqMissing()
+        {
+            using var context = CreateDbContext();
+            var controller = CreateController(context);
+
+            var result = await controller.UpdateFaq(999, new UpdateFaqDto
+            {
+                Question = "Q",
+                Answer = "A"
+            });
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public async Task DeleteFaq_ShouldRemoveFromDatabase()
+        {
+            using var context = CreateDbContext();
+            context.Faqs.Add(new DAL.Entities.Faq
+            {
+                Question = "Q?",
+                Answer = "A",
+                IsActive = true,
+                CreatedDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+            var faqId = context.Faqs.First().FaqId;
+
+            var controller = CreateController(context);
+            var result = await controller.DeleteFaq(faqId);
+
+            result.Should().BeOfType<NoContentResult>();
+            (await context.Faqs.CountAsync()).Should().Be(0);
+        }
+
+        [Fact]
+        public async Task DeleteFaq_ShouldReturnNotFound_WhenFaqMissing()
+        {
+            using var context = CreateDbContext();
+            var controller = CreateController(context);
+
+            var result = await controller.DeleteFaq(999);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Fact]
+        public async Task GetAllFaqs_ShouldIncludeInactiveEntries()
+        {
+            using var context = CreateDbContext();
+            context.Faqs.AddRange(
+                new DAL.Entities.Faq { Question = "Active?", Answer = "y", IsActive = true,  SortOrder = 1, CreatedDate = DateTime.UtcNow },
+                new DAL.Entities.Faq { Question = "Inactive?", Answer = "n", IsActive = false, SortOrder = 2, CreatedDate = DateTime.UtcNow }
+            );
+            await context.SaveChangesAsync();
+
+            var controller = CreateController(context);
+
+            var result = await controller.GetAllFaqs();
+            var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+            var body = ok.Value.Should().BeAssignableTo<IEnumerable<GetFaqDto>>().Subject.ToList();
+            body.Should().HaveCount(2);
+
+            var publicResult = await controller.GetFaqs();
+            var publicOk = publicResult.Should().BeOfType<OkObjectResult>().Subject;
+            var publicBody = publicOk.Value.Should().BeAssignableTo<IEnumerable<GetFaqDto>>().Subject.ToList();
+            publicBody.Should().HaveCount(1);
+            publicBody[0].Question.Should().Be("Active?");
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/SelfAssignIntegrationTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/Integration/SelfAssignIntegrationTests.cs
@@ -1,0 +1,223 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using System.Security.Claims;
+using TelecomSupportSystem.API.Controllers;
+using TelecomSupportSystem.BLL.DTOs.Tickets;
+using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL;
+using TelecomSupportSystem.DAL.Entities;
+using TelecomSupportSystem.DAL.Entities.Enums;
+using TelecomSupportSystem.DAL.Repositories;
+using Xunit;
+
+namespace TelecomSupportSystem.Tests.Integration
+{
+    // PB-62 / US-105: End-to-end testovi samodjelovanja tiketa (Controller → Service → Repository → DB).
+    public class SelfAssignIntegrationTests
+    {
+        private static ApplicationDbContext CreateDbContext() =>
+            new(new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        private static TicketController CreateController(ApplicationDbContext context, int userId, string role)
+        {
+            var service = new TicketService(
+                new TicketRepository(context),
+                new TeamRepository(context),
+                new UserRepository(context),
+                new Mock<INotificationService>().Object,
+                new Mock<ICommentService>().Object);
+            var controller = new TicketController(service);
+
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, userId.ToString()),
+                new(ClaimTypes.Role, role),
+            };
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test")) }
+            };
+            return controller;
+        }
+
+        private static User MakeClient(int id) => new()
+        {
+            UserId = id,
+            FirstName = "Client",
+            LastName = $"{id}",
+            Email = $"c{id}@test.ba",
+            Username = $"c{id}",
+            PasswordHash = "h",
+            Role = Role.CLIENT,
+            AccountStatus = AccountStatus.ACTIVE,
+        };
+
+        private static User MakeAgent(int id, int teamId) => new()
+        {
+            UserId = id,
+            FirstName = $"Agent{id}",
+            LastName = "Test",
+            Email = $"a{id}@test.ba",
+            Username = $"a{id}",
+            PasswordHash = "h",
+            Role = Role.AGENT,
+            AccountStatus = AccountStatus.ACTIVE,
+            AvailabilityStatus = AvailabilityStatus.AVAILABLE,
+            TeamId = teamId,
+        };
+
+        private static Ticket MakeUnassignedTicket(int id, int creatorId, int? teamId = null) => new()
+        {
+            TicketId = id,
+            Title = "Tiket",
+            Description = "Opis",
+            CreatorId = creatorId,
+            Status = TicketStatus.OPEN,
+            Priority = Priority.MEDIUM,
+            ProblemCategory = ProblemCategory.INTERNET,
+            CreatedDate = DateTime.UtcNow,
+            TeamId = teamId,
+        };
+
+        [Fact]
+        public async Task SelfAssign_ShouldAssignTicket_ToCallingAgent()
+        {
+            using var context = CreateDbContext();
+            context.Teams.Add(new Team
+            {
+                TeamId = 1,
+                TeamName = "Internet Tim",
+                TeamType = TeamType.AGENTS,
+                TeamStatus = TeamStatus.ACTIVE,
+                SpecializedCategory = ProblemCategory.INTERNET
+            });
+            context.Users.AddRange(MakeClient(1), MakeAgent(10, 1));
+            context.Tickets.Add(MakeUnassignedTicket(100, creatorId: 1, teamId: 1));
+            await context.SaveChangesAsync();
+
+            var controller = CreateController(context, userId: 10, role: "AGENT");
+
+            var result = await controller.SelfAssignTicket(100);
+
+            var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+            var dto = ok.Value.Should().BeOfType<AgentScoreDto>().Subject;
+            dto.UserId.Should().Be(10);
+
+            context.Set<TicketUser>().Should().ContainSingle(a =>
+                a.TicketId == 100
+                && a.UserId == 10
+                && a.AssignmentType == AssignmentType.MANUAL);
+        }
+
+        [Fact]
+        public async Task SelfAssign_ShouldReturnForbid_ForNonAgents()
+        {
+            using var context = CreateDbContext();
+            context.Users.Add(MakeClient(1));
+            context.Tickets.Add(MakeUnassignedTicket(100, creatorId: 1));
+            await context.SaveChangesAsync();
+
+            var clientController = CreateController(context, userId: 1, role: "CLIENT");
+            var clientResult = await clientController.SelfAssignTicket(100);
+            clientResult.Should().BeOfType<ForbidResult>();
+
+            var techController = CreateController(context, userId: 1, role: "TECHNICIAN");
+            var techResult = await techController.SelfAssignTicket(100);
+            techResult.Should().BeOfType<ForbidResult>();
+
+            var adminController = CreateController(context, userId: 1, role: "ADMINISTRATOR");
+            var adminResult = await adminController.SelfAssignTicket(100);
+            adminResult.Should().BeOfType<ForbidResult>();
+
+            context.Set<TicketUser>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task SelfAssign_ShouldReturnBadRequest_WhenAlreadyAssignedToAnotherAgent()
+        {
+            using var context = CreateDbContext();
+            context.Teams.Add(new Team
+            {
+                TeamId = 1,
+                TeamName = "Internet Tim",
+                TeamType = TeamType.AGENTS,
+                TeamStatus = TeamStatus.ACTIVE,
+                SpecializedCategory = ProblemCategory.INTERNET
+            });
+            context.Users.AddRange(MakeClient(1), MakeAgent(10, 1), MakeAgent(11, 1));
+            context.Tickets.Add(MakeUnassignedTicket(100, creatorId: 1, teamId: 1));
+            context.Set<TicketUser>().Add(new TicketUser
+            {
+                TicketId = 100,
+                UserId = 11,
+                TeamId = 1,
+                AssignmentDate = DateTime.UtcNow,
+                AssignmentType = AssignmentType.AUTOMATIC,
+            });
+            await context.SaveChangesAsync();
+
+            var controller = CreateController(context, userId: 10, role: "AGENT");
+
+            var result = await controller.SelfAssignTicket(100);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+            context.Set<TicketUser>().Should().ContainSingle()
+                .Which.UserId.Should().Be(11);
+        }
+
+        [Fact]
+        public async Task SelfAssign_ShouldReturnBadRequest_WhenTicketIsClosed()
+        {
+            using var context = CreateDbContext();
+            context.Teams.Add(new Team
+            {
+                TeamId = 1,
+                TeamName = "Internet Tim",
+                TeamType = TeamType.AGENTS,
+                TeamStatus = TeamStatus.ACTIVE,
+                SpecializedCategory = ProblemCategory.INTERNET
+            });
+            context.Users.AddRange(MakeClient(1), MakeAgent(10, 1));
+            var closed = MakeUnassignedTicket(100, creatorId: 1, teamId: 1);
+            closed.Status = TicketStatus.CLOSED;
+            closed.ClosedDate = DateTime.UtcNow;
+            context.Tickets.Add(closed);
+            await context.SaveChangesAsync();
+
+            var controller = CreateController(context, userId: 10, role: "AGENT");
+
+            var result = await controller.SelfAssignTicket(100);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+            context.Set<TicketUser>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task SelfAssign_ShouldReturnNotFound_WhenTicketDoesNotExist()
+        {
+            using var context = CreateDbContext();
+            context.Users.Add(MakeAgent(10, 1));
+            context.Teams.Add(new Team
+            {
+                TeamId = 1,
+                TeamName = "Internet Tim",
+                TeamType = TeamType.AGENTS,
+                TeamStatus = TeamStatus.ACTIVE,
+                SpecializedCategory = ProblemCategory.INTERNET
+            });
+            await context.SaveChangesAsync();
+
+            var controller = CreateController(context, userId: 10, role: "AGENT");
+
+            var result = await controller.SelfAssignTicket(999);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+    }
+}

--- a/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/SelfAssignServiceTests.cs
+++ b/Project/TelecomSupportSystem/TelecomSupportSystem.Tests/TicketT/SelfAssignServiceTests.cs
@@ -1,0 +1,184 @@
+using FluentAssertions;
+using Moq;
+using TelecomSupportSystem.BLL.Services;
+using TelecomSupportSystem.BLL.Services.Interfaces;
+using TelecomSupportSystem.DAL.Entities;
+using TelecomSupportSystem.DAL.Entities.Enums;
+using TelecomSupportSystem.DAL.Repositories.Interfaces;
+using Xunit;
+
+namespace TelecomSupportSystem.Tests.Tickets
+{
+    // PB-62 / US-105: Unit testovi samodjelovanja tiketa (agent „Preuzmi tiket")
+    public class SelfAssignServiceTests
+    {
+        private readonly Mock<ITicketRepository> _ticketRepoMock = new();
+        private readonly Mock<ITeamRepository> _teamRepoMock = new();
+        private readonly Mock<IUserRepository> _userRepoMock = new();
+        private readonly Mock<INotificationService> _notificationServiceMock = new();
+        private readonly Mock<ICommentService> _commentServiceMock = new();
+        private readonly TicketService _service;
+
+        public SelfAssignServiceTests()
+        {
+            _service = new TicketService(
+                _ticketRepoMock.Object,
+                _teamRepoMock.Object,
+                _userRepoMock.Object,
+                _notificationServiceMock.Object,
+                _commentServiceMock.Object);
+        }
+
+        private static Ticket MakeTicket(int id = 1, TicketStatus status = TicketStatus.OPEN, int? teamId = 1)
+            => new()
+            {
+                TicketId = id,
+                Title = "Test tiket",
+                Description = "Opis",
+                CreatorId = 99,
+                Status = status,
+                Priority = Priority.MEDIUM,
+                ProblemCategory = ProblemCategory.INTERNET,
+                CreatedDate = DateTime.UtcNow,
+                TeamId = teamId,
+                Assignments = new List<TicketUser>()
+            };
+
+        private static User MakeAgent(int id = 10, int? teamId = 1) => new()
+        {
+            UserId = id,
+            FirstName = "Agent",
+            LastName = id.ToString(),
+            Email = $"a{id}@test.ba",
+            Username = $"a{id}",
+            PasswordHash = "h",
+            Role = Role.AGENT,
+            AccountStatus = AccountStatus.ACTIVE,
+            TeamId = teamId,
+        };
+
+        // ─── Pozitivan slučaj ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldAssignTicket_ToCallingAgent()
+        {
+            var ticket = MakeTicket();
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+            _userRepoMock.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(MakeAgent());
+
+            var result = await _service.SelfAssignTicketAsync(1, 10);
+
+            result.UserId.Should().Be(10);
+            _ticketRepoMock.Verify(r => r.AddAssignmentAsync(It.Is<TicketUser>(
+                a => a.UserId == 10
+                  && a.TicketId == 1
+                  && a.AssignmentType == AssignmentType.MANUAL
+                  && a.TeamId == 1)), Times.Once);
+        }
+
+        // PB-62: nakon uspjeha mora se obavijestiti klijent i dodati zapis u istoriju tiketa
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldNotifyClientAndAddSystemComment_OnSuccess()
+        {
+            var ticket = MakeTicket();
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+            _userRepoMock.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(MakeAgent());
+
+            await _service.SelfAssignTicketAsync(1, 10);
+
+            _notificationServiceMock.Verify(n => n.SendNotificationAsync(
+                99,
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                NotificationType.TICKET_ASSIGNED,
+                1), Times.Once);
+            _commentServiceMock.Verify(c => c.AddSystemCommentAsync(
+                1,
+                It.Is<string>(s => s.Contains("preuzeo"))), Times.Once);
+        }
+
+        // ─── Negativni slučajevi ──────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldThrowKeyNotFound_WhenTicketMissing()
+        {
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(7)).ReturnsAsync((Ticket?)null);
+
+            var act = () => _service.SelfAssignTicketAsync(7, 10);
+
+            await act.Should().ThrowAsync<KeyNotFoundException>();
+            _ticketRepoMock.Verify(r => r.AddAssignmentAsync(It.IsAny<TicketUser>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldThrow_WhenTicketIsClosed()
+        {
+            var ticket = MakeTicket(status: TicketStatus.CLOSED);
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+
+            var act = () => _service.SelfAssignTicketAsync(1, 10);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            _ticketRepoMock.Verify(r => r.AddAssignmentAsync(It.IsAny<TicketUser>()), Times.Never);
+        }
+
+        // PB-62: agent ne smije preuzeti tiket koji je već dodijeljen drugom agentu
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldThrow_WhenTicketAlreadyAssigned()
+        {
+            var ticket = MakeTicket();
+            ticket.Assignments.Add(new TicketUser
+            {
+                AssignmentId = 1,
+                TicketId = 1,
+                UserId = 55,
+                TeamId = 1,
+                AssignmentDate = DateTime.UtcNow,
+                AssignmentType = AssignmentType.AUTOMATIC,
+                User = new User { UserId = 55, FirstName = "Drugi", LastName = "Agent", Role = Role.AGENT }
+            });
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+
+            var act = () => _service.SelfAssignTicketAsync(1, 10);
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .WithMessage("*već dodijeljen*");
+            _ticketRepoMock.Verify(r => r.AddAssignmentAsync(It.IsAny<TicketUser>()), Times.Never);
+        }
+
+        // PB-62: klijent/tehničar/administrator ne mogu raditi self-assign — provjera role
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldThrow_WhenCallerIsNotAgent()
+        {
+            var ticket = MakeTicket();
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+            _userRepoMock.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(new User
+            {
+                UserId = 10,
+                FirstName = "Tech",
+                LastName = "User",
+                Email = "t@t.ba",
+                Username = "t",
+                PasswordHash = "h",
+                Role = Role.TECHNICIAN,
+                AccountStatus = AccountStatus.ACTIVE,
+            });
+
+            var act = () => _service.SelfAssignTicketAsync(1, 10);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        }
+
+        [Fact]
+        public async Task SelfAssignTicketAsync_ShouldThrow_WhenAgentHasNoTeamAndTicketHasNoTeam()
+        {
+            var ticket = MakeTicket(teamId: null);
+            _ticketRepoMock.Setup(r => r.GetByIdWithDetailsAsync(1)).ReturnsAsync(ticket);
+            _userRepoMock.Setup(r => r.GetByIdAsync(10)).ReturnsAsync(MakeAgent(teamId: null));
+
+            var act = () => _service.SelfAssignTicketAsync(1, 10);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
+    }
+}

--- a/Project/frontend/src/pages/Faq.jsx
+++ b/Project/frontend/src/pages/Faq.jsx
@@ -1,20 +1,45 @@
 import { useCallback, useEffect, useState } from 'react'
-import { AlertCircle, ChevronDown, HelpCircle, RefreshCcw } from 'lucide-react'
-import { getFaqs } from '../services/faqService'
+import { AlertCircle, ChevronDown, HelpCircle, Pencil, Plus, RefreshCcw, Trash2, X } from 'lucide-react'
+import {
+  createFaq,
+  deleteFaq,
+  getAllFaqs,
+  getFaqs,
+  updateFaq,
+} from '../services/faqService'
+import { useAuth } from '../context/AuthContext'
 import EmptyState from '../components/common/EmptyState'
+import ConfirmDialog from '../components/common/ConfirmDialog'
+import Modal from '../components/common/Modal'
+
+const EMPTY_FORM = { question: '', answer: '', category: '', sortOrder: 0 }
 
 export default function Faq() {
+  const { user } = useAuth()
+  const isAdmin = user?.role === 'ADMINISTRATOR'
+
   const [faqs, setFaqs] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [openFaqId, setOpenFaqId] = useState(null)
+  const [notification, setNotification] = useState(null)
+
+  // Admin form state
+  const [formOpen, setFormOpen] = useState(false)
+  const [editingFaq, setEditingFaq] = useState(null)
+  const [formValues, setFormValues] = useState(EMPTY_FORM)
+  const [formError, setFormError] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Delete confirmation
+  const [deletingFaq, setDeletingFaq] = useState(null)
 
   const loadFaqs = useCallback(async () => {
     setLoading(true)
     setError(null)
 
     try {
-      const data = await getFaqs()
+      const data = isAdmin ? await getAllFaqs() : await getFaqs()
       setFaqs(data)
     } catch (err) {
       console.error(err)
@@ -22,12 +47,14 @@ export default function Faq() {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [isAdmin])
 
   useEffect(() => {
     let isMounted = true
 
-    getFaqs()
+    const fetcher = isAdmin ? getAllFaqs : getFaqs
+
+    fetcher()
       .then((data) => {
         if (isMounted) {
           setFaqs(data)
@@ -48,10 +75,95 @@ export default function Faq() {
     return () => {
       isMounted = false
     }
-  }, [])
+  }, [isAdmin])
 
   const toggleFaq = (faqId) => {
     setOpenFaqId((current) => (current === faqId ? null : faqId))
+  }
+
+  const showNotification = (type, message) => {
+    setNotification({ type, message })
+    setTimeout(() => setNotification(null), 3000)
+  }
+
+  const openCreateForm = () => {
+    setEditingFaq(null)
+    setFormValues(EMPTY_FORM)
+    setFormError(null)
+    setFormOpen(true)
+  }
+
+  const openEditForm = (faq) => {
+    setEditingFaq(faq)
+    setFormValues({
+      question: faq.question ?? '',
+      answer: faq.answer ?? '',
+      category: faq.category ?? '',
+      sortOrder: faq.sortOrder ?? 0,
+    })
+    setFormError(null)
+    setFormOpen(true)
+  }
+
+  const closeForm = () => {
+    setFormOpen(false)
+    setEditingFaq(null)
+    setFormValues(EMPTY_FORM)
+    setFormError(null)
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setFormError(null)
+
+    if (!formValues.question.trim()) {
+      setFormError('Pitanje ne smije biti prazno.')
+      return
+    }
+    if (!formValues.answer.trim()) {
+      setFormError('Odgovor ne smije biti prazan.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload = {
+        question: formValues.question.trim(),
+        answer: formValues.answer.trim(),
+        category: formValues.category.trim() || null,
+        sortOrder: Number(formValues.sortOrder) || 0,
+      }
+
+      if (editingFaq) {
+        await updateFaq(editingFaq.faqId, payload)
+        showNotification('success', 'FAQ stavka je uspješno ažurirana.')
+      } else {
+        await createFaq(payload)
+        showNotification('success', 'Nova FAQ stavka je uspješno dodana.')
+      }
+
+      await loadFaqs()
+      closeForm()
+    } catch (err) {
+      console.error(err)
+      setFormError(err.response?.data?.poruka || 'Greška pri čuvanju FAQ stavke.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deletingFaq) return
+    const targetId = deletingFaq.faqId
+    setDeletingFaq(null)
+    try {
+      await deleteFaq(targetId)
+      showNotification('success', 'FAQ stavka je obrisana.')
+      await loadFaqs()
+    } catch (err) {
+      console.error(err)
+      showNotification('error', err.response?.data?.poruka || 'Greška pri brisanju FAQ stavke.')
+    }
   }
 
   return (
@@ -61,14 +173,45 @@ export default function Faq() {
           <div className="w-11 h-11 rounded-xl bg-white/10 flex items-center justify-center shrink-0">
             <HelpCircle size={22} className="text-navy-100" />
           </div>
-          <div>
+          <div className="flex-1">
             <h2 className="text-xl font-bold">Često postavljana pitanja</h2>
             <p className="text-sm text-navy-200 mt-1">
               Brzi odgovori za najčešće probleme sa internetom, TV uslugom, mobilnom mrežom i tiketima.
             </p>
           </div>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={openCreateForm}
+              className="inline-flex items-center gap-2 px-4 py-2 bg-white text-navy-800 text-sm font-semibold rounded-lg hover:bg-navy-50 transition-colors"
+            >
+              <Plus size={16} />
+              Dodaj pitanje
+            </button>
+          )}
         </div>
       </section>
+
+      {notification && (
+        <div
+          role="status"
+          className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg border text-sm font-medium ${
+            notification.type === 'success'
+              ? 'bg-green-50 text-green-700 border-green-100'
+              : 'bg-red-50 text-red-700 border-red-100'
+          }`}
+        >
+          <span>{notification.message}</span>
+          <button
+            type="button"
+            onClick={() => setNotification(null)}
+            className="text-current opacity-70 hover:opacity-100"
+            aria-label="Zatvori obavještenje"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      )}
 
       <section className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
         {loading ? (
@@ -99,7 +242,11 @@ export default function Faq() {
           <EmptyState
             icon={HelpCircle}
             title="Nema FAQ pitanja"
-            description="Trenutno nema dostupnih odgovora. Provjerite kasnije ili otvorite novi tiket za podršku."
+            description={
+              isAdmin
+                ? 'Još uvijek nije dodano nijedno pitanje. Kliknite „Dodaj pitanje" da kreirate prvo.'
+                : 'Trenutno nema dostupnih odgovora. Provjerite kasnije ili otvorite novi tiket za podršku.'
+            }
           />
         ) : (
           <div className="divide-y divide-gray-100">
@@ -108,27 +255,50 @@ export default function Faq() {
 
               return (
                 <article key={faq.faqId} className="px-5 py-4">
-                  <button
-                    type="button"
-                    onClick={() => toggleFaq(faq.faqId)}
-                    aria-expanded={isOpen}
-                    className="w-full flex items-start justify-between gap-4 text-left"
-                  >
-                    <span>
-                      {faq.category && (
-                        <span className="inline-flex items-center rounded-full bg-navy-50 px-2.5 py-0.5 text-xs font-medium text-navy-700 mb-2">
-                          {faq.category}
+                  <div className="flex items-start gap-3">
+                    <button
+                      type="button"
+                      onClick={() => toggleFaq(faq.faqId)}
+                      aria-expanded={isOpen}
+                      className="flex-1 flex items-start justify-between gap-4 text-left"
+                    >
+                      <span>
+                        {faq.category && (
+                          <span className="inline-flex items-center rounded-full bg-navy-50 px-2.5 py-0.5 text-xs font-medium text-navy-700 mb-2">
+                            {faq.category}
+                          </span>
+                        )}
+                        <span className="block text-sm font-semibold text-gray-900">
+                          {faq.question}
                         </span>
-                      )}
-                      <span className="block text-sm font-semibold text-gray-900">
-                        {faq.question}
                       </span>
-                    </span>
-                    <ChevronDown
-                      size={20}
-                      className={`text-gray-400 mt-1 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-                    />
-                  </button>
+                      <ChevronDown
+                        size={20}
+                        className={`text-gray-400 mt-1 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                      />
+                    </button>
+
+                    {isAdmin && (
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => openEditForm(faq)}
+                          aria-label={`Uredi pitanje ${faq.question}`}
+                          className="p-1.5 text-gray-500 hover:text-navy-700 hover:bg-navy-50 rounded-md transition-colors"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setDeletingFaq(faq)}
+                          aria-label={`Obriši pitanje ${faq.question}`}
+                          className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    )}
+                  </div>
 
                   {isOpen && (
                     <p className="text-sm text-gray-600 leading-6 mt-3 pr-8">
@@ -141,6 +311,110 @@ export default function Faq() {
           </div>
         )}
       </section>
+
+      {isAdmin && (
+        <Modal
+          isOpen={formOpen}
+          onClose={closeForm}
+          title={editingFaq ? 'Uredi FAQ stavku' : 'Dodaj novu FAQ stavku'}
+          size="md"
+        >
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="faq-question" className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+                Pitanje
+              </label>
+              <input
+                id="faq-question"
+                type="text"
+                value={formValues.question}
+                onChange={(e) => setFormValues((prev) => ({ ...prev, question: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-navy-500 focus:border-navy-500 outline-none"
+                placeholder="Unesite pitanje..."
+              />
+            </div>
+
+            <div>
+              <label htmlFor="faq-answer" className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+                Odgovor
+              </label>
+              <textarea
+                id="faq-answer"
+                rows={5}
+                value={formValues.answer}
+                onChange={(e) => setFormValues((prev) => ({ ...prev, answer: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-navy-500 focus:border-navy-500 outline-none resize-none"
+                placeholder="Unesite odgovor..."
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="faq-category" className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+                  Kategorija
+                </label>
+                <input
+                  id="faq-category"
+                  type="text"
+                  value={formValues.category}
+                  onChange={(e) => setFormValues((prev) => ({ ...prev, category: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-navy-500 focus:border-navy-500 outline-none"
+                  placeholder="npr. Internet"
+                />
+              </div>
+              <div>
+                <label htmlFor="faq-sortorder" className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1">
+                  Redoslijed
+                </label>
+                <input
+                  id="faq-sortorder"
+                  type="number"
+                  value={formValues.sortOrder}
+                  onChange={(e) => setFormValues((prev) => ({ ...prev, sortOrder: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-navy-500 focus:border-navy-500 outline-none"
+                />
+              </div>
+            </div>
+
+            {formError && (
+              <div role="alert" className="flex items-center gap-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                <AlertCircle size={14} />
+                {formError}
+              </div>
+            )}
+
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-gray-100">
+              <button
+                type="button"
+                onClick={closeForm}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+              >
+                Odustani
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-4 py-2 text-sm font-semibold bg-navy-700 hover:bg-navy-800 text-white rounded-lg transition-colors disabled:opacity-50"
+              >
+                {submitting ? 'Čuvanje...' : editingFaq ? 'Sačuvaj izmjene' : 'Dodaj pitanje'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+
+      {isAdmin && (
+        <ConfirmDialog
+          isOpen={Boolean(deletingFaq)}
+          onClose={() => setDeletingFaq(null)}
+          onConfirm={handleConfirmDelete}
+          title="Obriši FAQ stavku"
+          message={deletingFaq ? `Jeste li sigurni da želite obrisati pitanje „${deletingFaq.question}"? Ova akcija se ne može poništiti.` : ''}
+          confirmText="Obriši"
+          cancelText="Odustani"
+          variant="danger"
+        />
+      )}
     </div>
   )
 }

--- a/Project/frontend/src/pages/TicketDetail.jsx
+++ b/Project/frontend/src/pages/TicketDetail.jsx
@@ -5,6 +5,7 @@ import {
     ArrowRightLeft,
     Bot,
     CheckCircle,
+    UserPlus,
     Clock,
     MessageCircle,
     Send,
@@ -27,6 +28,7 @@ import {
     getAgentScores,
     getTicketComments,
     forwardTicketToTechnician,
+    selfAssignTicket,
     updateInternalPriority,
     closeTicket,
     requestTicketClosure,
@@ -472,6 +474,28 @@ export default function TicketDetail() {
             setForwardError(err.response?.data?.poruka || 'Prosljeđivanje nije uspješno.')
         } finally {
             setForwardLoading(false)
+        }
+    }
+
+    // PB-62 / US-105: Agent preuzima nedodijeljeni tiket
+    const [selfAssignLoading, setSelfAssignLoading] = useState(false)
+    const [selfAssignError, setSelfAssignError] = useState(null)
+
+    const handleSelfAssign = async () => {
+        setSelfAssignLoading(true)
+        setSelfAssignError(null)
+        try {
+            await selfAssignTicket(Number(id))
+            const updatedTicket = await getTicketById(Number(id))
+            setTicket(updatedTicket)
+            setStatusNotification({ type: 'success', message: 'Tiket je dodijeljen vama.' })
+            setTimeout(() => setStatusNotification(null), 3000)
+        } catch (err) {
+            const msg = err.response?.data?.poruka || 'Tiket nije dostupan ili je već dodijeljen drugom agentu.'
+            setSelfAssignError(msg)
+            setTimeout(() => setSelfAssignError(null), 5000)
+        } finally {
+            setSelfAssignLoading(false)
         }
     }
 
@@ -1009,6 +1033,29 @@ export default function TicketDetail() {
                                                             {timeLeftMs !== null && timeLeftMs <= 86400000 && (
                                                                 <AlertCircle size={12} className="ml-0.5" />
                                                             )}
+                                                        </div>
+                                                    )}
+                                                </>
+                                            )}
+                                            {/* PB-62 / US-105: Agent samodjelovanje — vidljivo samo kad je tiket otvoren i nedodijeljen */}
+                                            {user?.role === 'AGENT'
+                                                && ticket.status === 'OPEN'
+                                                && !ticket.assignedAgentId
+                                                && !ticket.assignedTechnicianId && (
+                                                <>
+                                                    <button
+                                                        type="button"
+                                                        disabled={selfAssignLoading}
+                                                        onClick={handleSelfAssign}
+                                                        className="w-full inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-navy-700 bg-navy-50 hover:bg-navy-100 rounded-lg transition-colors disabled:opacity-50"
+                                                    >
+                                                        <UserPlus size={15} />
+                                                        {selfAssignLoading ? 'Preuzimanje...' : 'Preuzmi tiket'}
+                                                    </button>
+                                                    {selfAssignError && (
+                                                        <div role="alert" className="flex items-center gap-2 text-xs text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                                                            <AlertCircle size={13} />
+                                                            {selfAssignError}
                                                         </div>
                                                     )}
                                                 </>

--- a/Project/frontend/src/services/faqService.js
+++ b/Project/frontend/src/services/faqService.js
@@ -4,3 +4,24 @@ export async function getFaqs() {
   const response = await api.get('/faq')
   return response.data
 }
+
+// PB-61 / US-104: Admin lista (uključuje neaktivne)
+export async function getAllFaqs() {
+  const response = await api.get('/faq/all')
+  return response.data
+}
+
+export async function createFaq(payload) {
+  const response = await api.post('/faq', payload)
+  return response.data
+}
+
+export async function updateFaq(faqId, payload) {
+  const response = await api.put(`/faq/${faqId}`, payload)
+  return response.data
+}
+
+export async function deleteFaq(faqId) {
+  const response = await api.delete(`/faq/${faqId}`)
+  return response.data
+}

--- a/Project/frontend/src/services/ticketService.js
+++ b/Project/frontend/src/services/ticketService.js
@@ -118,6 +118,12 @@ export async function forwardTicketToTechnician(ticketId) {
   return response.data
 }
 
+// PB-62 / US-105: Agent preuzima nedodijeljeni tiket sebi
+export async function selfAssignTicket(ticketId) {
+  const response = await api.post(`/tickets/${ticketId}/self-assign`)
+  return response.data
+}
+
 // Internal Priority Management
 export async function updateInternalPriority(ticketId, priority) {
   const response = await api.post(`/tickets/${ticketId}/internal-priority`, { priority })

--- a/Project/frontend/src/test/Faq.test.jsx
+++ b/Project/frontend/src/test/Faq.test.jsx
@@ -3,10 +3,23 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
   getFaqs: vi.fn(),
+  getAllFaqs: vi.fn(),
+  createFaq: vi.fn(),
+  updateFaq: vi.fn(),
+  deleteFaq: vi.fn(),
+  useAuth: vi.fn(),
 }))
 
 vi.mock('../services/faqService', () => ({
   getFaqs: mocks.getFaqs,
+  getAllFaqs: mocks.getAllFaqs,
+  createFaq: mocks.createFaq,
+  updateFaq: mocks.updateFaq,
+  deleteFaq: mocks.deleteFaq,
+}))
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: mocks.useAuth,
 }))
 
 import Faq from '../pages/Faq'
@@ -39,12 +52,13 @@ function deferred() {
   return { promise, resolve, reject }
 }
 
-describe('Faq page', () => {
+describe('Faq page — read-only (CLIENT)', () => {
   let consoleErrorSpy
 
   beforeEach(() => {
     vi.clearAllMocks()
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.useAuth.mockReturnValue({ user: { role: 'CLIENT' } })
   })
 
   afterEach(() => {
@@ -112,5 +126,170 @@ describe('Faq page', () => {
     fireEvent.click(screen.getByRole('button', { name: /kako resetovati ruter/i }))
 
     expect(screen.queryByText('Isključite ruter 30 sekundi.')).not.toBeInTheDocument()
+  })
+
+  // PB-61 / US-104: ne-admin korisnici ne smiju vidjeti CRUD kontrole
+  it('does not render admin CRUD controls for non-admin users', async () => {
+    mocks.getFaqs.mockResolvedValueOnce(FAKE_FAQS)
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText('Kako resetovati ruter?')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /dodaj pitanje/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /uredi pitanje/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /obriši pitanje/i })).not.toBeInTheDocument()
+  })
+
+  it('CLIENT uses public endpoint and not admin endpoint', async () => {
+    mocks.getFaqs.mockResolvedValueOnce(FAKE_FAQS)
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText('Kako resetovati ruter?')).toBeInTheDocument())
+
+    expect(mocks.getFaqs).toHaveBeenCalled()
+    expect(mocks.getAllFaqs).not.toHaveBeenCalled()
+  })
+})
+
+// PB-61 / US-104: Admin CRUD nad FAQ stavkama
+describe('Faq page — admin CRUD (ADMINISTRATOR)', () => {
+  let consoleErrorSpy
+
+  beforeEach(() => {
+    // vi.resetAllMocks resetuje i mockResolvedValueOnce queue između testova
+    vi.resetAllMocks()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.useAuth.mockReturnValue({ user: { role: 'ADMINISTRATOR' } })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('uses admin endpoint and renders edit/delete controls for admin', async () => {
+    mocks.getAllFaqs.mockResolvedValue(FAKE_FAQS)
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText('Kako resetovati ruter?')).toBeInTheDocument())
+
+    expect(mocks.getAllFaqs).toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /dodaj pitanje/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /uredi pitanje kako resetovati ruter/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /obriši pitanje kako resetovati ruter/i })).toBeInTheDocument()
+  })
+
+  // PB-61 / US-104: validacija praznog pitanja u admin formi
+  it('shows validation error when question is empty', async () => {
+    mocks.getAllFaqs.mockResolvedValue([])
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText(/Nema FAQ pitanja/i)).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /dodaj pitanje/i }))
+
+    // Modal je otvoren; pronađi submit dugme (zadnje sa nazivom „Dodaj pitanje")
+    const submitButtons = screen.getAllByRole('button', { name: /dodaj pitanje/i })
+    fireEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/pitanje ne smije biti prazno/i)
+    )
+    expect(mocks.createFaq).not.toHaveBeenCalled()
+  })
+
+  it('shows validation error when answer is empty', async () => {
+    mocks.getAllFaqs.mockResolvedValue([])
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText(/Nema FAQ pitanja/i)).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /dodaj pitanje/i }))
+    fireEvent.change(screen.getByLabelText('Pitanje', { selector: 'input' }), { target: { value: 'Validno pitanje?' } })
+
+    const submitButtons = screen.getAllByRole('button', { name: /dodaj pitanje/i })
+    fireEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/odgovor ne smije biti prazan/i)
+    )
+    expect(mocks.createFaq).not.toHaveBeenCalled()
+  })
+
+  it('creates a new FAQ when form is valid', async () => {
+    mocks.getAllFaqs.mockResolvedValue([])
+    mocks.createFaq.mockResolvedValue({})
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText(/Nema FAQ pitanja/i)).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /dodaj pitanje/i }))
+    fireEvent.change(screen.getByLabelText('Pitanje', { selector: 'input' }), { target: { value: 'Novo pitanje?' } })
+    fireEvent.change(screen.getByLabelText('Odgovor', { selector: 'textarea' }), { target: { value: 'Novi odgovor.' } })
+
+    const submitButtons = screen.getAllByRole('button', { name: /dodaj pitanje/i })
+    fireEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(mocks.createFaq).toHaveBeenCalledWith(
+        expect.objectContaining({
+          question: 'Novo pitanje?',
+          answer: 'Novi odgovor.',
+        })
+      )
+    )
+  })
+
+  it('opens edit form pre-filled and submits update', async () => {
+    mocks.getAllFaqs.mockResolvedValue(FAKE_FAQS)
+    mocks.updateFaq.mockResolvedValue({})
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText('Kako resetovati ruter?')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /uredi pitanje kako resetovati ruter/i }))
+
+    const questionInput = screen.getByLabelText('Pitanje', { selector: 'input' })
+    expect(questionInput.value).toBe('Kako resetovati ruter?')
+
+    fireEvent.change(questionInput, { target: { value: 'Izmijenjeno pitanje?' } })
+    fireEvent.click(screen.getByRole('button', { name: /sačuvaj izmjene/i }))
+
+    await waitFor(() =>
+      expect(mocks.updateFaq).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ question: 'Izmijenjeno pitanje?' })
+      )
+    )
+  })
+
+  it('confirms deletion before calling delete API and refreshes list', async () => {
+    mocks.getAllFaqs.mockResolvedValue(FAKE_FAQS)
+    mocks.deleteFaq.mockResolvedValue({})
+
+    render(<Faq />)
+
+    await waitFor(() => expect(screen.getByText('Kako resetovati ruter?')).toBeInTheDocument())
+
+    const initialLoadCount = mocks.getAllFaqs.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: /obriši pitanje kako resetovati ruter/i }))
+
+    // ConfirmDialog se otvori sa „Obriši" akcijom
+    const confirmButtons = screen.getAllByRole('button', { name: /^obriši$/i })
+    expect(confirmButtons.length).toBeGreaterThan(0)
+    fireEvent.click(confirmButtons[confirmButtons.length - 1])
+
+    await waitFor(() => expect(mocks.deleteFaq).toHaveBeenCalledWith(1))
+    // nakon brisanja, lista se mora osvježiti (loadFaqs → getAllFaqs)
+    await waitFor(() =>
+      expect(mocks.getAllFaqs.mock.calls.length).toBeGreaterThan(initialLoadCount)
+    )
   })
 })

--- a/Project/frontend/src/test/TicketDetail.test.jsx
+++ b/Project/frontend/src/test/TicketDetail.test.jsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getTicketComments: vi.fn(),
   addComment: vi.fn(),
   getTicketRating: vi.fn(),
+  selfAssignTicket: vi.fn(),
   useAuth: vi.fn(),
   HubConnectionBuilder: vi.fn(),
 }))
@@ -16,6 +17,7 @@ vi.mock('../services/ticketService', () => ({
   getTicketComments: mocks.getTicketComments,
   addComment: mocks.addComment,
   getTicketRating: mocks.getTicketRating,
+  selfAssignTicket: mocks.selfAssignTicket,
   createTicketRating: vi.fn(),
   closeTicket: vi.fn(),
   requestTicketClosure: vi.fn(),
@@ -217,5 +219,136 @@ describe('TicketDetail page — PB-24, PB-27', () => {
 
     const sendButton = screen.getByText(/pošalji/i).closest('button')
     expect(sendButton).toBeDisabled()
+  })
+})
+
+// PB-62 / US-105: Samodjelovanje tiketa za agente („Preuzmi tiket")
+describe('TicketDetail — PB-62 self-assign', () => {
+  const UNASSIGNED_OPEN_TICKET = {
+    ticketId: 5,
+    title: 'Internet ne radi',
+    description: 'Opis problema.',
+    status: 'OPEN',
+    priority: 'HIGH',
+    problemCategory: 'INTERNET',
+    createdDate: '2026-05-01T10:00:00Z',
+    clientName: 'Merjem Omerović',
+    assignedAgentName: '',
+    assignedAgentId: null,
+    assignedTechnicianName: '',
+    assignedTechnicianId: null,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getTicketRating.mockResolvedValue(null)
+  })
+
+  it('shows "Preuzmi tiket" button for AGENT when ticket is open and unassigned', async () => {
+    mocks.getTicketById.mockResolvedValueOnce(UNASSIGNED_OPEN_TICKET)
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'AGENT', userId: 11 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: /preuzmi tiket/i })).toBeInTheDocument()
+  })
+
+  it('hides "Preuzmi tiket" button for CLIENT', async () => {
+    mocks.getTicketById.mockResolvedValueOnce({ ...UNASSIGNED_OPEN_TICKET, creatorId: 1 })
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'CLIENT', userId: 1 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+  })
+
+  it('hides "Preuzmi tiket" button for TECHNICIAN', async () => {
+    mocks.getTicketById.mockResolvedValueOnce(UNASSIGNED_OPEN_TICKET)
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'TECHNICIAN', userId: 8 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+  })
+
+  it('hides "Preuzmi tiket" button for ADMINISTRATOR', async () => {
+    mocks.getTicketById.mockResolvedValueOnce(UNASSIGNED_OPEN_TICKET)
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'ADMINISTRATOR', userId: 1 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+  })
+
+  it('hides "Preuzmi tiket" button when ticket already has assigned agent', async () => {
+    mocks.getTicketById.mockResolvedValueOnce({
+      ...UNASSIGNED_OPEN_TICKET,
+      assignedAgentId: 99,
+      assignedAgentName: 'Druga Osoba',
+    })
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'AGENT', userId: 11 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+  })
+
+  it('hides "Preuzmi tiket" button when ticket is closed', async () => {
+    mocks.getTicketById.mockResolvedValueOnce({ ...UNASSIGNED_OPEN_TICKET, status: 'CLOSED' })
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    renderTicketDetail({ role: 'AGENT', userId: 11 }, '5')
+
+    await waitFor(() => expect(screen.getByText('Internet ne radi')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+  })
+
+  it('clicking "Preuzmi tiket" calls selfAssignTicket and refreshes ticket', async () => {
+    const assignedTicket = {
+      ...UNASSIGNED_OPEN_TICKET,
+      assignedAgentId: 11,
+      assignedAgentName: 'Selma Mujić',
+    }
+    mocks.getTicketById
+      .mockResolvedValueOnce(UNASSIGNED_OPEN_TICKET)
+      .mockResolvedValueOnce(assignedTicket)
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    mocks.selfAssignTicket.mockResolvedValueOnce({ userId: 11, fullName: 'Selma Mujić' })
+
+    renderTicketDetail({ role: 'AGENT', userId: 11 }, '5')
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /preuzmi tiket/i })).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /preuzmi tiket/i }))
+
+    await waitFor(() => expect(mocks.selfAssignTicket).toHaveBeenCalledWith(5))
+    // UI mora pokazati agenta kao dodjeljenog i sakriti dugme
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /preuzmi tiket/i })).not.toBeInTheDocument()
+    )
+    expect(screen.getByText('Selma Mujić')).toBeInTheDocument()
+  })
+
+  it('shows error message when self-assign fails (backend reject — already assigned)', async () => {
+    mocks.getTicketById.mockResolvedValueOnce(UNASSIGNED_OPEN_TICKET)
+    mocks.getTicketComments.mockResolvedValueOnce([])
+    mocks.selfAssignTicket.mockRejectedValueOnce({
+      response: { data: { poruka: 'Tiket je već dodijeljen drugom agentu.' } },
+    })
+
+    renderTicketDetail({ role: 'AGENT', userId: 11 }, '5')
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /preuzmi tiket/i })).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /preuzmi tiket/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/već dodijeljen/i)
+    )
   })
 })

--- a/Project/frontend/src/test/acceptance/FaqAcceptance.test.jsx
+++ b/Project/frontend/src/test/acceptance/FaqAcceptance.test.jsx
@@ -3,10 +3,20 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
   getFaqs: vi.fn(),
+  getAllFaqs: vi.fn(),
+  useAuth: vi.fn(() => ({ user: { role: 'CLIENT' } })),
 }))
 
 vi.mock('../../services/faqService', () => ({
   getFaqs: mocks.getFaqs,
+  getAllFaqs: mocks.getAllFaqs,
+  createFaq: vi.fn(),
+  updateFaq: vi.fn(),
+  deleteFaq: vi.fn(),
+}))
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: mocks.useAuth,
 }))
 
 import Faq from '../../pages/Faq'

--- a/Project/frontend/src/test/faqService.test.js
+++ b/Project/frontend/src/test/faqService.test.js
@@ -3,11 +3,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 vi.mock('../services/api', () => ({
   default: {
     get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
   },
 }))
 
 import api from '../services/api'
-import { getFaqs } from '../services/faqService'
+import {
+  createFaq,
+  deleteFaq,
+  getAllFaqs,
+  getFaqs,
+  updateFaq,
+} from '../services/faqService'
 
 describe('faqService', () => {
   beforeEach(() => {
@@ -29,5 +38,42 @@ describe('faqService', () => {
     const result = await getFaqs()
 
     expect(result).toEqual(faqs)
+  })
+
+  // PB-61 / US-104: Admin endpointi
+
+  it('getAllFaqs() calls GET /faq/all (admin endpoint)', async () => {
+    api.get.mockResolvedValueOnce({ data: [] })
+
+    await getAllFaqs()
+
+    expect(api.get).toHaveBeenCalledWith('/faq/all')
+  })
+
+  it('createFaq() POSTs payload to /faq', async () => {
+    const payload = { question: 'Q?', answer: 'A.', category: 'Internet', sortOrder: 1 }
+    api.post.mockResolvedValueOnce({ data: { faqId: 5, ...payload } })
+
+    const result = await createFaq(payload)
+
+    expect(api.post).toHaveBeenCalledWith('/faq', payload)
+    expect(result.faqId).toBe(5)
+  })
+
+  it('updateFaq() PUTs payload to /faq/:id', async () => {
+    const payload = { question: 'Q2?', answer: 'A2.', category: null, sortOrder: 2 }
+    api.put.mockResolvedValueOnce({ data: { faqId: 9, ...payload } })
+
+    await updateFaq(9, payload)
+
+    expect(api.put).toHaveBeenCalledWith('/faq/9', payload)
+  })
+
+  it('deleteFaq() DELETEs /faq/:id', async () => {
+    api.delete.mockResolvedValueOnce({ data: undefined })
+
+    await deleteFaq(11)
+
+    expect(api.delete).toHaveBeenCalledWith('/faq/11')
   })
 })

--- a/Project/frontend/src/test/system/FaqSystem.test.jsx
+++ b/Project/frontend/src/test/system/FaqSystem.test.jsx
@@ -3,10 +3,20 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
   getFaqs: vi.fn(),
+  getAllFaqs: vi.fn(),
+  useAuth: vi.fn(() => ({ user: { role: 'CLIENT' } })),
 }))
 
 vi.mock('../../services/faqService', () => ({
   getFaqs: mocks.getFaqs,
+  getAllFaqs: mocks.getAllFaqs,
+  createFaq: vi.fn(),
+  updateFaq: vi.fn(),
+  deleteFaq: vi.fn(),
+}))
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: mocks.useAuth,
 }))
 
 import Faq from '../../pages/Faq'

--- a/Project/frontend/src/test/ticketService.test.js
+++ b/Project/frontend/src/test/ticketService.test.js
@@ -8,7 +8,7 @@ vi.mock('../services/api', () => ({
 }))
 
 import api from '../services/api'
-import { getMyTickets, createTicket, getAllTickets, getTicketById, getTicketComments, addComment } from '../services/ticketService'
+import { getMyTickets, createTicket, getAllTickets, getTicketById, getTicketComments, addComment, selfAssignTicket } from '../services/ticketService'
 
 describe('ticketService', () => {
   beforeEach(() => {
@@ -149,5 +149,24 @@ describe('ticketService', () => {
     const result = await addComment(5, 'Nova poruka')
 
     expect(result).toEqual(comment)
+  })
+
+  // ─── selfAssignTicket (PB-62 / US-105) ───────────────────────────────────
+
+  it('selfAssignTicket() calls POST /tickets/:id/self-assign', async () => {
+    api.post.mockResolvedValueOnce({ data: { userId: 10, fullName: 'Agent Test' } })
+
+    await selfAssignTicket(42)
+
+    expect(api.post).toHaveBeenCalledWith('/tickets/42/self-assign')
+  })
+
+  it('selfAssignTicket() returns assignment response from API', async () => {
+    const response = { userId: 10, fullName: 'Agent Test', scorePercent: 100 }
+    api.post.mockResolvedValueOnce({ data: response })
+
+    const result = await selfAssignTicket(42)
+
+    expect(result).toEqual(response)
   })
 })

--- a/Project/frontend/src/test/ui/FaqUi.test.jsx
+++ b/Project/frontend/src/test/ui/FaqUi.test.jsx
@@ -3,10 +3,20 @@ import { render, screen, waitFor } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
   getFaqs: vi.fn(),
+  getAllFaqs: vi.fn(),
+  useAuth: vi.fn(() => ({ user: { role: 'CLIENT' } })),
 }))
 
 vi.mock('../../services/faqService', () => ({
   getFaqs: mocks.getFaqs,
+  getAllFaqs: mocks.getAllFaqs,
+  createFaq: vi.fn(),
+  updateFaq: vi.fn(),
+  deleteFaq: vi.fn(),
+}))
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: mocks.useAuth,
 }))
 
 import Faq from '../../pages/Faq'


### PR DESCRIPTION
This pull request introduces significant enhancements to the FAQ management and ticket assignment features in the Telecom Support System. It adds full CRUD (Create, Read, Update, Delete) support for FAQ entries, including admin-only endpoints and validation, and implements a new "self-assign" action for agents to claim unassigned tickets. The changes involve new DTOs, service and repository methods, and controller endpoints, improving both admin and agent workflows.

**FAQ Management Enhancements:**

* Added CRUD operations for FAQs, including admin-only endpoints to list all (including inactive), create, update, and delete FAQ entries in `FaqController`, with appropriate authorization and error handling.
* Introduced `CreateFaqDto` and `UpdateFaqDto` classes for creating and updating FAQ entries, respectively. [[1]](diffhunk://#diff-32353374f550fe49f1b3da3d027fc7670c59bba97dfeeb765a9865354a4710e9R1-R10) [[2]](diffhunk://#diff-185cc22edd5662c71ba22e4f55601edb46cb8a4f51fcba6a3c958a8431c78153R1-R10)
* Extended `IFaqService` and `FaqService` to support listing all FAQs, creating, updating, and deleting FAQ entries, with validation for required fields and consistent error messages. [[1]](diffhunk://#diff-01242d7a1c7dc916fafaf6cba98b6f92f31996cac18048030f002fdb786d84f6R8-R16) [[2]](diffhunk://#diff-ef09c463a953a7c77ee1d4a67550c027c4bf571a268d2410d9c699f0b79286b4R3-R13) [[3]](diffhunk://#diff-ef09c463a953a7c77ee1d4a67550c027c4bf571a268d2410d9c699f0b79286b4L20-R93)
* Updated `IFaqRepository` and `FaqRepository` to support retrieval, creation, update, and deletion of FAQ entries, including fetching all (not just active) FAQs. [[1]](diffhunk://#diff-1d9a74f6209ded5713980e8e4c8254134a156cb85b87e36cdb11747d701963e4R8-R18) [[2]](diffhunk://#diff-f31bf0c24c525bae4fbbf9d1359545e6c503a1a989a8cc090f7c92851160f20aR25-R57)

**Ticket Assignment Improvements:**

* Added a new endpoint in `TicketController` allowing agents to self-assign unassigned, open tickets, with role checks and detailed error handling.
* Implemented `SelfAssignTicketAsync` in `ITicketService` and `TicketService`, ensuring only agents can self-assign tickets that are not closed or already assigned, and logging/auditing the action. [[1]](diffhunk://#diff-1917e69be10fe28b8c996b8a45c20fc66347befa4a9c95ad651725ec3e4a0326R40-R42) [[2]](diffhunk://#diff-ddd1bffa441940a410b670626b9994419c594cc1909457afd69ce8ab13ca4149R742-R810)